### PR TITLE
MAINT: use a larger type for simple_reduce

### DIFF
--- a/examples/kokkos/02_simple_reduce.py
+++ b/examples/kokkos/02_simple_reduce.py
@@ -5,7 +5,7 @@ import pykokkos as pk
 class SquareSum:
     def __init__(self, n):
         self.N: int = n
-        self.total: int = 0
+        self.total: pk.double = 0
 
     @pk.main
     def run(self):


### PR DESCRIPTION
Fixes #6 (well up to a smaller value at least..)

* use a larger type for the total variable
in `02_simple_reduce.py` to prevent overflow
at larger square sum values, and to match
the type of the accumulator that is used

* this seems to allow `9000` to be handled,
though not `90000`, based on comparison
with i.e., `np.sum(np.arange(9000) ** 2)`

* I also noticed that this adjustment
only helps if I manually purge the `pk_cpp`
folder (no recompile on the variable
type change?)