### PR TITLE
TST: assert_allclose for test_float_sum

### DIFF
--- a/tests/test_kokkosfunctions_translator.py
+++ b/tests/test_kokkosfunctions_translator.py
@@ -166,7 +166,7 @@ class TestKokkosFunctionsTranslator(unittest.TestCase):
         expected_result: float = self.threads * (self.f_1 + self.f_2)
         result: float = pk.parallel_reduce(self.range_policy, self.functor.add_floats)
 
-        assert_allclose(expected_result, result)
+        assert_allclose(result, expected_result)
 
     def test_nested_sum(self):
         expected_result: int = self.threads * (self.i_1 + self.i_2)

--- a/tests/test_kokkosfunctions_translator.py
+++ b/tests/test_kokkosfunctions_translator.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pykokkos as pk
+from numpy.testing import assert_allclose
 
 
 # Tests translation of KOKKOS_FUNCTIONS to C++
@@ -165,7 +166,7 @@ class TestKokkosFunctionsTranslator(unittest.TestCase):
         expected_result: float = self.threads * (self.f_1 + self.f_2)
         result: float = pk.parallel_reduce(self.range_policy, self.functor.add_floats)
 
-        self.assertEqual(expected_result, result)
+        assert_allclose(expected_result, result)
 
     def test_nested_sum(self):
         expected_result: int = self.threads * (self.i_1 + self.i_2)


### PR DESCRIPTION
Fixes #9

* use the NumPy testing function `assert_allclose()`
for the floating-point assertion in `test_float_sum()`
because requiring exact floating point equality was
causing falures for me on one of our `clx-volta` nodes

* I'm assuming that a dependency on NumPy for the
testsuite should be "ok" (test-time deps are usually
less serious than runtime deps, etc.)