### PR TITLE
TST: add a runtests file

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,4 @@
+# force pytest to actually import
+# all the test modules directly
+import pytest
+pytest.main()


### PR DESCRIPTION
* add a simple module we can use to run tests with `pytest`
via `python runtests.py` -- this circumvents some of the
issues with `pykokkos` relying on `main()` blocks and the
details of importing

* we could eventually expand this module to have some of the
same features of `runtests.py` in:
- NumPy: https://github.com/numpy/numpy/blob/main/runtests.py
- SciPy: https://github.com/scipy/scipy/blob/main/runtests.py

* that said, my main objective here is just to give us an easy
way to run `pytest` locally and in CI; the main things we may
want to add in the future might be support for
- running the testsuite with multiple cores (`-n` flag)
- running with coverage (`pytest-cov`, etc.)

* obviously, you can already run the testsuite with `unittest`
by `pytest` is so standard/expected now we should probably just
support it if the burden is not too great I think

* eventually, being able to use `pytest` directly on the command
line would be nice, but strikes me as requiring a bit more magic
with import machinery, so this may be acceptable for the short-term
at least