### PR TITLE
MAINT: rm duplication in bindings module

### DIFF
--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -176,7 +176,6 @@ def generate_copy_back(members: PyKokkosMembers) -> str:
             continue
 
         # skip views with user-set memory spaces
-        view_type: cppast.ClassType = members.views[cppast.DeclRefExpr(v)]
         if get_view_memory_space(view_type) == Keywords.ArgMemSpace.value:
             continue
 


### PR DESCRIPTION
* the tests seem to pass without this duplication
detected by `mypy`; I haven't yet checked if the
current tests flush this code path though

* the original `mypy` complaint was:
  - `pykokkos/core/translators/bindings.py:179: error: Name "view_type" already defined on line 173`

Incidentally, I was kind of thinking a scoped `mypy` check might be an easy way to get CI rolling (i.e., start with a tiny bit of static type analysis, then ramp up to `runtests.py` and all the compiled dependencies).