### PR TITLE
TST: purge cache when testing

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,14 @@
+import os
+import shutil
+import pytest
+
+# purge pk_cpp folder so that the
+# test suite actually translates and
+# compiles the code under test
+cwd = os.getcwd()
+shutil.rmtree(os.path.join(cwd, "pk_cpp"),
+              ignore_errors=True)
+
 # force pytest to actually import
 # all the test modules directly
-import pytest
 pytest.main()


### PR DESCRIPTION
* adjust `runtests.py` to purge the compiled
"cache" between tests, otherwise we might miss
compilation issues while iterating on the code

* on one of our `clx-volta` nodes this changes the
repeated test suite time on a single core from around
25 seconds to 185 seconds, which is consistent with
the translation/compilation happening on each repeat
incantation of the test suite