### PR TITLE
TST: runtests specific tests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import pytest
@@ -9,6 +10,19 @@ cwd = os.getcwd()
 shutil.rmtree(os.path.join(cwd, "pk_cpp"),
               ignore_errors=True)
 
+
+# try to support command line arguments to
+# runtests.py that mirror direct usage of
+# pytest
+pytest_args = []
+
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--specifictests', type=str)
+args = parser.parse_args()
+
+if args.specifictests:
+    pytest_args.append(args.specifictests)
+
 # force pytest to actually import
 # all the test modules directly
-pytest.main()
+pytest.main(pytest_args)


### PR DESCRIPTION
* add the ability to run specific test modules/classes/files
with `runtests.py`, largely copying the design from SciPy/NumPy

* note that they are considering a complete overhaul of their
CLI tools (https://github.com/scipy/scipy/issues/15489) but for
now I'm just trying to mimic the crucial things we need for `pytest`

* some example incantations on this branch:
  - run a single test module: `python runtests.py -t tests/test_views.py`
    - `9 passed, 3 warnings in 77.47s (0:01:17)`
  - run an individual test: `python runtests.py -t tests/test_atomics.py::TestAtomic::test_atomic_xor`
    - `1 passed, 3 warnings in 12.55s`
  - run a single test class: `python runtests.py -t tests/test_atomics.py::TestAtomic`
    - `12 passed, 3 warnings in 12.81s`
  - run the entire suite again: `python runtests.py`
    - `89 passed, 3 warnings in 189.67s (0:03:09)`