### PR TITLE
WIP, CI: Add initial CI with mypy

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,0 +1,33 @@
+name: Python Testing
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  test_pykokkos:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade numpy mypy
+      - name: Install pykokkos
+        run: |
+          python -m pip install .
+      - name: mypy check
+        run: |
+          mypy pykokkos

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,94 @@
+[mypy]
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True
+plugins = numpy.typing.mypy_plugin
+
+# third party dependencies
+
+[mypy-kokkos]
+ignore_missing_imports = True
+
+[mypy-pykokkos.bindings.bindings.libpykokkos]
+ignore_missing_imports = True
+
+# pykokkos modules with multiple errors
+
+[mypy-pykokkos.interface.accumulator]
+ignore_errors = True
+
+[mypy-pykokkos.interface.views]
+ignore_errors = True
+
+[mypy-pykokkos.core.translators.functor]
+ignore_errors = True
+
+[mypy-pykokkos.core.translators.static]
+ignore_errors = True
+
+[mypy-pykokkos.core.compiler]
+ignore_errors = True
+
+[mypy-pykokkos.core.runtime]
+ignore_errors = True
+
+[mypy-pykokkos.core.cppast.decl]
+ignore_errors = True
+
+[mypy-pykokkos.kokkos_manager]
+ignore_errors = True
+
+[mypy-pykokkos.interface.execution_policy]
+ignore_errors = True
+
+[mypy-pykokkos.interface.parallel_dispatch]
+ignore_errors = True
+
+[mypy-pykokkos.interface.atomic.atomic_fetch_op]
+ignore_errors = True
+
+[mypy-pykokkos.interface]
+ignore_errors = True
+
+[mypy-pykokkos.core.run_debug]
+ignore_errors = True
+
+[mypy-pykokkos.core.cpp_setup]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.visitors_util]
+ignore_errors = True
+
+[mypy-pykokkos.core.parsers.parser]
+ignore_errors = True
+
+[mypy-pykokkos.core.module_setup]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.pykokkos_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.parameter_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.constructor_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.workunit_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.kokkosmain_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.kokkosfunction_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.visitors.classtype_visitor]
+ignore_errors = True
+
+[mypy-pykokkos.core.translators.members]
+ignore_errors = True
+
+[mypy-pykokkos.core.translators.bindings]
+ignore_errors = True
+


### PR DESCRIPTION
### Description
* Add config file for `mypy` such that no errors are raised

* Add GitHub actions CI testing

This is an initial trial that I tested on my [fork](https://github.com/nawtrey/pykokkos/pull/1) with Python 3.8-3.10, which passed for all 3 Python versions. The CI is currently pinned to the `develop` branch, and I have the `mypy.ini` set to ignore basically every module. There are simpler ways of accomplishing this, but I went with a per-module approach so they can easily be removed one at a time, and corrected in subsequent PR's. Eventually it would be nice to have all of the modules passing, of course. 

Commenting out any module will result in some number of errors (as many as 50+ for some), with the exception of the `mypy-pykokkos.bindings.bindings.libpykokkos`, which only raised an error in the CI:
```
pykokkos/bindings/bindings/__init__.py:59: error: Skipping analyzing "pykokkos.bindings.bindings.libpykokkos": module is installed, but missing library stubs or py.typed marker  [import]
pykokkos/bindings/bindings/__init__.py:59: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 55 source files)
```