### PR TITLE
CI: bump GHA versions

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
* [follow NumPy](https://github.com/numpy/numpy/pull/21307) in bumping the GitHub `actions` to
their latest versions