### PR TITLE
ENH: reduction type expand

### DIFF
--- a/pykokkos/core/visitors/workunit_visitor.py
+++ b/pykokkos/core/visitors/workunit_visitor.py
@@ -200,7 +200,11 @@ class WorkunitVisitor(PyKokkosVisitor):
         is_hierachical: bool = isinstance(node.annotation, ast.Attribute)
 
         if is_hierachical:
-            decltype.typename = f"const {decltype.typename}"
+            try:
+                decltype.typename = f"const {decltype.typename}"
+            except AttributeError:
+                decltype._type = f"const {decltype.typename.value}"
+
             decltype.is_reference = True
 
         declname = cppast.DeclRefExpr(node.arg)

--- a/tests/test_parallelreduce.py
+++ b/tests/test_parallelreduce.py
@@ -70,7 +70,7 @@ class SquareSumInt:
         self.total = pk.parallel_reduce(self.N, self.squaresum)
 
     @pk.workunit
-    def squaresum(self, i: int, acc: pk.Acc[pk.int64]):
+    def squaresum(self, i: pk.int64, acc: pk.Acc[pk.int64]):
         acc += i * i
 
 
@@ -79,8 +79,6 @@ class SquareSumInt:
 def test_squaresum_types(series_max, dtype):
     # check for the ability to match NumPy in
     # sum of squares reductions with various types
-    if series_max == 90000 and dtype == np.int64:
-        pytest.xfail("see gh-24")
     expected = np.sum(np.arange(series_max, dtype=dtype) ** 2)
     if dtype == np.float64:
         ss_instance = SquareSumFloat(series_max)


### PR DESCRIPTION
Fixes #24

* we can now use `pk.int64` for variables (beyond
the accumulator) in parallel reductions, which
improves our range of integer reduction sizes

* remove the known failure from `test_squaresum_types()`
since we now match NumPy for `np.int64` at larger
values there