### PR TITLE
ENH: expose pk.reciprocal

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -12,6 +12,7 @@ from pykokkos.kokkos_manager import (
 )
 
 initialize()
+from pykokkos.lib.ufuncs import reciprocal # type: ignore
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,33 +1,28 @@
+from functools import singledispatch
+
 import pykokkos as pk
 
 # NOTE: it might be slick if we could encapsulate
-# the workload code inside of the ufunc definitions,
+# the workunit code inside of the ufunc definitions,
 # but we currently require global scoping
 
 
-@pk.workload
-class ReciprocalView1D:
-    def __init__(self, view: pk.View1D[pk.double]):
-        # TODO: why doesn't view have a "size"
-        # attribute? it is basically the shape product
-        # in higher dims
-        self.threads: int = view.shape[0] # type: ignore
-        self.view: pk.View1D[pk.double] = view
+@pk.workunit
+def reciprocal_impl_1d_double(view: pk.View1D[pk.double], tid: int):
+    view[tid] = 1 / view[tid] # type: ignore
 
-    @pk.main
-    def run(self) -> None:
-        pk.parallel_for(self.threads, self.pfor)
+@pk.workunit
+def reciprocal_impl_1d_single(view: pk.View1D[pk.single], tid: int):
+    view[tid] = 1 / view[tid] # type: ignore
 
-    @pk.workunit
-    def pfor(self, tid: int) -> None:
-        self.view[tid] = 1 / self.view[tid] # type: ignore
 
 
 # TODO: how are we going to "ufunc dispatch" when the view
 # has a different type/precision? i.e., something other than
 # pk.double?
 
-def reciprocal(view: pk.View1D[pk.double]):
+@singledispatch
+def reciprocal(view):
     """
     Return the reciprocal of the argument, element-wise.
 
@@ -47,15 +42,16 @@ def reciprocal(view: pk.View1D[pk.double]):
         This function is not designed to work with integers.
 
     """
-    workload_instance = ReciprocalView1D(view=view)
-    # NOTE: should our ufuncs have an option to allow
-    # CUDA vs. OpenMP execution directly in their call
-    # signature?
-    pk.execute(pk.ExecutionSpace.Default, workload_instance)
-    # TODO: how should we design this?
-    # it seems a bit problematic to both mutate the data
-    # underneath a view in-place and return a reference to the view?
-    # returning a new view/"array" would be more similar to
-    # NumPy?
-    return workload_instance.view
+    pass
+
+
+@reciprocal.register
+def _(view: pk.View1D[pk.double]):
+    pk.parallel_for(view.shape[0], reciprocal_impl_1d_double, view=view)
+    return view
+
+@reciprocal.register
+def _(view: pk.View1D[pk.single]):
+    pk.parallel_for(view.shape[0], reciprocal_impl_1d_single, view=view)
+    return view
     

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,39 +1,28 @@
-from functools import singledispatch
-
 import pykokkos as pk
 
-# NOTE: it might be slick if we could encapsulate
-# the workunit code inside of the ufunc definitions,
-# but we currently require global scoping
-
 
 @pk.workunit
-def reciprocal_impl_1d_double(view: pk.View1D[pk.double], tid: int):
-    view[tid] = 1 / view[tid] # type: ignore
-
-@pk.workunit
-def reciprocal_impl_1d_single(view: pk.View1D[pk.single], tid: int):
+def reciprocal_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
     view[tid] = 1 / view[tid] # type: ignore
 
 
+@pk.workunit
+def reciprocal_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = 1 / view[tid] # type: ignore
 
-# TODO: how are we going to "ufunc dispatch" when the view
-# has a different type/precision? i.e., something other than
-# pk.double?
 
-@singledispatch
 def reciprocal(view):
     """
     Return the reciprocal of the argument, element-wise.
 
     Parameters
     ----------
-    view : pk.View1D
+    view : pykokkos view
            Input view.
 
     Returns
     -------
-    y : pk.View1D
+    y : pykokkos view
         Output view.
 
     Notes
@@ -42,16 +31,13 @@ def reciprocal(view):
         This function is not designed to work with integers.
 
     """
-    pass
-
-
-@reciprocal.register
-def _(view: pk.View1D[pk.double]):
-    pk.parallel_for(view.shape[0], reciprocal_impl_1d_double, view=view)
+    # see gh-29 for some discussion of the dispatching
+    # awkwardness used here
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], reciprocal_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], reciprocal_impl_1d_float, view=view)
+    # NOTE: pretty awkward to both return the view
+    # and operate on it in place; the former is closer
+    # to NumPy semantics
     return view
-
-@reciprocal.register
-def _(view: pk.View1D[pk.single]):
-    pk.parallel_for(view.shape[0], reciprocal_impl_1d_single, view=view)
-    return view
-    

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,0 +1,61 @@
+import pykokkos as pk
+
+# NOTE: it might be slick if we could encapsulate
+# the workload code inside of the ufunc definitions,
+# but we currently require global scoping
+
+
+@pk.workload
+class ReciprocalView1D:
+    def __init__(self, view: pk.View1D[pk.double]):
+        # TODO: why doesn't view have a "size"
+        # attribute? it is basically the shape product
+        # in higher dims
+        self.threads: int = view.shape[0] # type: ignore
+        self.view: pk.View1D[pk.double] = view
+
+    @pk.main
+    def run(self) -> None:
+        pk.parallel_for(self.threads, self.pfor)
+
+    @pk.workunit
+    def pfor(self, tid: int) -> None:
+        self.view[tid] = 1 / self.view[tid] # type: ignore
+
+
+# TODO: how are we going to "ufunc dispatch" when the view
+# has a different type/precision? i.e., something other than
+# pk.double?
+
+def reciprocal(view: pk.View1D[pk.double]):
+    """
+    Return the reciprocal of the argument, element-wise.
+
+    Parameters
+    ----------
+    view : pk.View1D
+           Input view.
+
+    Returns
+    -------
+    y : pk.View1D
+        Output view.
+
+    Notes
+    -----
+    .. note::
+        This function is not designed to work with integers.
+
+    """
+    workload_instance = ReciprocalView1D(view=view)
+    # NOTE: should our ufuncs have an option to allow
+    # CUDA vs. OpenMP execution directly in their call
+    # signature?
+    pk.execute(pk.ExecutionSpace.Default, workload_instance)
+    # TODO: how should we design this?
+    # it seems a bit problematic to both mutate the data
+    # underneath a view in-place and return a reference to the view?
+    # returning a new view/"array" would be more similar to
+    # NumPy?
+    return workload_instance.view
+    

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -291,3 +291,17 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
     expected = numpy_ufunc(range(10))
     assert_allclose(actual, expected)
 
+
+@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+        (pk.reciprocal, np.reciprocal),
+])
+def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc, numpy_ufunc):
+    # test the ufuncs we have exposed in the pk namespace
+    # vs. their NumPy equivalents
+    expected = numpy_ufunc(np.arange(10, dtype=np.float64))
+
+    # TODO: parametrize test with more types somehow?
+    view: pk.View1d = pk.View([10], pk.double)
+    view[:] = np.arange(10, dtype=np.float64)
+    actual = pk_ufunc(view=view)
+    assert_allclose(actual, expected)

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -295,13 +295,19 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
 @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
         (pk.reciprocal, np.reciprocal),
 ])
-def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc, numpy_ufunc):
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                    numpy_ufunc,
+                                    pk_dtype,
+                                    numpy_dtype):
     # test the ufuncs we have exposed in the pk namespace
     # vs. their NumPy equivalents
-    expected = numpy_ufunc(np.arange(10, dtype=np.float64))
+    expected = numpy_ufunc(np.arange(10, dtype=numpy_dtype))
 
-    # TODO: parametrize test with more types somehow?
-    view: pk.View1d = pk.View([10], pk.double)
-    view[:] = np.arange(10, dtype=np.float64)
+    view: pk.View1d = pk.View([10], pk_dtype)
+    view[:] = np.arange(10, dtype=numpy_dtype)
     actual = pk_ufunc(view=view)
     assert_allclose(actual, expected)


### PR DESCRIPTION
* draft of new `pk.reciprocal()` "ufunc" exposed
for initial usage with 1D arrays of type `double`

* the diff contains various comments/design questions,
which is why I've only drafted 1 ufunc here so far; another
thing to keep in mind is how closely we'd like to match
the arguments from the original ufunc:
https://numpy.org/doc/stable/reference/generated/numpy.reciprocal.html

It is a bit tricky to compare timings, but with 4 OpenMP threads set
in my environment, `pykokkos` can perform quite a bit faster after
paying the cost of the initial compilation (which NumPy paid
previously when it was built ahead of time):

<details>

<summary> Small Python timing script details are below the fold </summary>

```python
import time

import numpy as np
from numpy.testing import assert_allclose
import pykokkos as pk

def main():
    # set up data structures
    size = 100000000
    arr = np.arange(size, dtype=np.float64)
    view: pk.View1D[pk.double] = pk.View([size], pk.double)
    view[:] = arr[:]

    start_numpy = time.perf_counter()
    numpy_result = np.reciprocal(arr)
    end_numpy = time.perf_counter()

    start_pk = time.perf_counter()
    pk_result = pk.reciprocal(view)
    end_pk = time.perf_counter()

    assert_allclose(pk_result, numpy_result)

    print("Time (s) for NumPy:", end_numpy - start_numpy)
    print("Time (s) for pykokkos:", end_pk - start_pk)

if __name__ == "__main__":
    main()

```

</details>

First benchmark pass (includes compile):
```
INFO:root:translation 0.0007879569966462441
INFO:root:compilation 4.233883150998736
Time (s) for NumPy: 0.14787226800399367
Time (s) for pykokkos: 4.306444576002832
```

Second benchmark pass (cached `pk_cpp` folder):

```
Time (s) for NumPy: 0.14742803500121227
Time (s) for pykokkos: 0.0750463389995275
```

Also of note that is it would be slick if we could use `timeit` in `ipython` more easily with `pykokkos`, but there are several blockers there at the moment (`main` /global related scoping stuff I think), not to mention the caution needed for operating "in place" on  views when you do repeat calculations, so that's why I wrote my own script there for now.

Obviously, the performance improvement would likely be more drastic with larger arrays and using GPU, but even with just a few threads this is already faster than NumPy with a roughly similar level of code complexity (I think there's probably a way to initialize views with less awkwardness than I've done here?).