### PR TITLE
BUG: cache no dead objects

### DIFF
--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -311,3 +311,13 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     view[:] = np.arange(10, dtype=numpy_dtype)
     actual = pk_ufunc(view=view)
     assert_allclose(actual, expected)
+
+
+def test_caching():
+    # regression test for gh-34
+    expected = np.reciprocal(np.arange(10, dtype=np.float32))
+    for i in range(300):
+        view: pk.View1d = pk.View([10], pk.float)
+        view[:] = np.arange(10, dtype=np.float32)
+        actual = pk.reciprocal(view=view)
+        assert_allclose(actual, expected)


### PR DESCRIPTION
Fixes #34

* ban the retrieval of objects from the cache
when any object in the cache has a reference count
of `0`, since this likely means that the reference
to a `pykokkos` object has been replaced by another
object, and the cache probably holds something invalid
at that point

* add a regression test, `test_caching()` that has a sufficiently
large number of iterations to trigger the Python garbage collection
machinery, and trigger this tricky issue; when it succeeds, this
test requires about 16 seconds locally

* I've added some comments to the source because we may need
to revisit the genuine value of the cache at some point, given
that views are mutable and not really safe to cache the data
they point to?