### PR TITLE
ENH: add pk.sqrt ufunc in 1D

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -16,7 +16,8 @@ from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
                                  log,
                                  log2,
                                  log10,
-                                 log1p)
+                                 log1p,
+                                 sqrt)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -75,6 +75,49 @@ def log(view):
     return view
 
 
+def sqrt_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = sqrt(view[tid]) # type: ignore
+
+
+@pk.workunit
+def sqrt_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = sqrt(view[tid]) # type: ignore
+
+
+def sqrt(view):
+    """
+    Return the non-negative square root of the argument, element-wise.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view
+        Output view.
+
+    Notes
+    -----
+    .. note::
+        This function should exhibit the same branch cut behavior
+        as the equivalent NumPy ufunc.
+    """
+    # TODO: support complex types when they
+    # are available in pykokkos?
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], sqrt_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], sqrt_impl_1d_float, view=view)
+    return view
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], log_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], log_impl_1d_float, view=view)
+    return view
+
+
 @pk.workunit
 def log2_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
     view[tid] = log2(view[tid]) # type: ignore
@@ -168,4 +211,3 @@ def log1p(view):
         pk.parallel_for(view.shape[0], log1p_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
-    return view

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -75,6 +75,7 @@ def log(view):
     return view
 
 
+@pk.workunit
 def sqrt_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
     view[tid] = sqrt(view[tid]) # type: ignore
 
@@ -110,11 +111,6 @@ def sqrt(view):
         pk.parallel_for(view.shape[0], sqrt_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], sqrt_impl_1d_float, view=view)
-    return view
-    if str(view.dtype) == "DataType.double":
-        pk.parallel_for(view.shape[0], log_impl_1d_double, view=view)
-    elif str(view.dtype) == "DataType.float":
-        pk.parallel_for(view.shape[0], log_impl_1d_float, view=view)
     return view
 
 
@@ -211,3 +207,4 @@ def log1p(view):
         pk.parallel_for(view.shape[0], log1p_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
+    return view

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -298,6 +298,7 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
         (pk.log2, np.log2),
         (pk.log10, np.log10),
         (pk.log1p, np.log1p),
+        (pk.sqrt, np.sqrt),
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
@@ -320,3 +321,21 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
         assert_allclose(actual, expected, rtol=1.5e-7)
     else:
         assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("arr", [
+    np.array([4, -1, np.inf]),
+    np.array([-np.inf, np.nan, np.inf]),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
+    # verify sqrt behavior for negative reals,
+    # NaN and infinite values
+    expected = np.sqrt(arr, dtype=numpy_dtype)
+    view: pk.View1d = pk.View([arr.size], pk_dtype)
+    view[:] = arr
+    actual = pk.sqrt(view=view)
+    assert_allclose(actual, expected)

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -339,3 +339,13 @@ def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
     view[:] = arr
     actual = pk.sqrt(view=view)
     assert_allclose(actual, expected)
+
+
+def test_caching():
+    # regression test for gh-34
+    expected = np.reciprocal(np.arange(10, dtype=np.float32))
+    for i in range(300):
+        view: pk.View1d = pk.View([10], pk.float)
+        view[:] = np.arange(10, dtype=np.float32)
+        actual = pk.reciprocal(view=view)
+        assert_allclose(actual, expected)


### PR DESCRIPTION
* add `double` and `float` versions of `pk.sqrt()`, and some tests to enforce behavioral similarity with `np.sqrt()` in 1D
* this PR temporarily cherry-picks the commit from gh-35, so that we can avoid caching/reference management issues that would otherwise prevent the expanded ufunc tests from passing