### PR TITLE
ENH: add 1D log ufuncs

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -12,7 +12,11 @@ from pykokkos.kokkos_manager import (
 )
 
 initialize()
-from pykokkos.lib.ufuncs import reciprocal # type: ignore
+from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
+                                 log,
+                                 log2,
+                                 log10,
+                                 log1p)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -41,3 +41,131 @@ def reciprocal(view):
     # and operate on it in place; the former is closer
     # to NumPy semantics
     return view
+
+
+@pk.workunit
+def log_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = log(view[tid]) # type: ignore
+
+
+@pk.workunit
+def log_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = log(view[tid]) # type: ignore
+
+
+def log(view):
+    """
+    Natural logarithm, element-wise.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view
+        Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], log_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], log_impl_1d_float, view=view)
+    return view
+
+
+@pk.workunit
+def log2_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = log2(view[tid]) # type: ignore
+
+
+@pk.workunit
+def log2_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = log2(view[tid]) # type: ignore
+
+
+def log2(view):
+    """
+    Base-2 logarithm, element-wise.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view
+        Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], log2_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], log2_impl_1d_float, view=view)
+    return view
+
+
+@pk.workunit
+def log10_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = log10(view[tid]) # type: ignore
+
+
+@pk.workunit
+def log10_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = log10(view[tid]) # type: ignore
+
+
+def log10(view):
+    """
+    Base-10 logarithm, element-wise.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view
+        Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], log10_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], log10_impl_1d_float, view=view)
+    return view
+
+
+@pk.workunit
+def log1p_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = log1p(view[tid]) # type: ignore
+
+
+@pk.workunit
+def log1p_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = log1p(view[tid]) # type: ignore
+
+
+def log1p(view):
+    """
+    Return the natural logarithm of one plus the input array, element-wise.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view
+        Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], log1p_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
+    return view

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -294,6 +294,10 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
 
 @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
         (pk.reciprocal, np.reciprocal),
+        (pk.log, np.log),
+        (pk.log2, np.log2),
+        (pk.log10, np.log10),
+        (pk.log1p, np.log1p),
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
@@ -310,4 +314,9 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     view: pk.View1d = pk.View([10], pk_dtype)
     view[:] = np.arange(10, dtype=numpy_dtype)
     actual = pk_ufunc(view=view)
-    assert_allclose(actual, expected)
+    # log10 single-precision needs relaxed tol
+    # for now
+    if numpy_ufunc == np.log10 and numpy_dtype == np.float32:
+        assert_allclose(actual, expected, rtol=1.5e-7)
+    else:
+        assert_allclose(actual, expected)


### PR DESCRIPTION
* add 1D `pykokkos` implementations of `log`, `log2`,
`log10`, and `log1p` ufuncs along with their inclusion
in the basic NumPy comparison test `test_1d_exposed_ufuncs_vs_numpy`

* looks like single-precision `log10` needs a slightly relaxed
tolerance for now (maybe C++ differences vs. NumPy ufunc loop),
but only a slight `rtol` bump

* we probably will want separate per-ufunc tests for corner
cases/complex numbers and so on, but some of that probably
depends on additional features in `pykokkos` anyway