### PR TITLE
ENH: support size attribute for views

### DIFF
--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import ctypes
+import math
 from enum import Enum
 import sys
 from typing import (
@@ -60,6 +61,7 @@ class ViewType:
     space: MemorySpace
     layout: Layout
     trait: Trait
+    size: int
 
     def rank(self) -> int:
         """
@@ -238,6 +240,7 @@ class View(ViewType):
         """
 
         self.shape: List[int] = shape
+        self.size = math.prod(shape)
         self.dtype: Optional[DataType] = self._get_type(dtype)
         if self.dtype is None:
             sys.exit(f"ERROR: Invalid dtype {dtype}")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -319,5 +319,19 @@ class TestViews(unittest.TestCase):
         pk.parallel_for(self.threads, f.pfor)
         pk.execute(pk.ExecutionSpace.Default, w)
 
+
+@pytest.mark.parametrize("input_arr, view_dims, view_type", [
+    (np.arange(10), [10], pk.View1D),
+    (np.arange(50).reshape(10, 5), [10, 5], pk.View2D),
+    (np.arange(500).reshape(10, 10, 5), [10, 10, 5], pk.View3D),
+    ])
+def test_sizes(input_arr, view_dims, view_type):
+    # regression test for gh-31
+    expected_size = input_arr.size
+    view: view_type = pk.View(view_dims)
+    view[:] = input_arr
+    assert view.size == expected_size
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #31

* include a regression test for 1D through 3D
views vs. NumPy `size` attributes