### PR TITLE
ENH: support for 1D pk.sign

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -92,3 +92,6 @@ ignore_errors = True
 [mypy-pykokkos.core.translators.bindings]
 ignore_errors = True
 
+[mypy-pykokkos.lib.ufuncs]
+ignore_errors = True
+

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -12,12 +12,13 @@ from pykokkos.kokkos_manager import (
 )
 
 initialize()
-from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
+from pykokkos.lib.ufuncs import (reciprocal,
                                  log,
                                  log2,
                                  log10,
                                  log1p,
-                                 sqrt)
+                                 sqrt,
+                                 sign)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -104,6 +104,7 @@ math_functions: Set = {
     "tan",
     "tanh",
     "trunc",
+    "nan",
 }
 
 math_constants: Dict[str, str] = {

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -224,3 +224,35 @@ def log1p(view):
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
     return view
+
+
+@pk.workunit
+def sign_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    if view[tid] > 0:
+        view[tid] = 1
+    elif view[tid] == 0:
+        view[tid] = 0
+    elif view[tid] < 0:
+        view[tid] = -1
+    else:
+        view[tid] = nan("")
+
+
+@pk.workunit
+def sign_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    if view[tid] > 0:
+        view[tid] = 1
+    elif view[tid] == 0:
+        view[tid] = 0
+    elif view[tid] < 0:
+        view[tid] = -1
+    else:
+        view[tid] = nan("")
+
+
+def sign(view):
+    if str(view.dtype) == "DataType.double":
+        pk.parallel_for(view.shape[0], sign_impl_1d_double, view=view)
+    elif str(view.dtype) == "DataType.float":
+        pk.parallel_for(view.shape[0], sign_impl_1d_float, view=view)
+    return view

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -300,6 +300,7 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
         (pk.log10, np.log10),
         (pk.log1p, np.log1p),
         (pk.sqrt, np.sqrt),
+        (pk.sign, np.sign),
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
@@ -370,4 +371,21 @@ def test_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
     view: pk.View2d = pk.View([5, 5], pk_dtype)
     view[:] = in_arr
     actual = pk_ufunc(view=view)
+    assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+@pytest.mark.parametrize("in_arr", [
+    np.array([-5, 4.5, np.nan]),
+    np.array([np.nan, np.nan, np.nan]),
+])
+def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
+    in_arr = in_arr.astype(numpy_dtype)
+    view: pk.View1D = pk.View([in_arr.size], pk_dtype)
+    view[:] = in_arr
+    expected = np.sign(in_arr)
+    actual = pk.sign(view=view)
     assert_allclose(actual, expected)


### PR DESCRIPTION
* add support for `pk.sign` ufunc on 1D views of type
`double` and `float`, and add regression tests against
the NumPy implementation

* this includes adding support for the C++ `nan()` `cmath`
function in workunits

* for now, we ignore type hints in the ufuncs module; can't
get that to behave properly with `mypy` yet

* I also tested the `pk.sign` implementation in SciPy itself,
with the motivation of eventually replacing larger chunks of
SciPy code with pykokkos ufuncs; see diff below or my feature
branch `treddy_voronoi_pykokkos_testing`, which appears to
pass the SciPy suite for this part of the code with
`time python dev.py test -j 1 -t scipy/spatial/tests/test_spherical_voronoi.py`
(as long as `pytest-xdist` is not used because of gh-14)

```diff
diff --git a/scipy/spatial/_spherical_voronoi.py b/scipy/spatial/_spherical_voronoi.py
index 42d557ddf..7c73f7300 100644
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -13,6 +13,7 @@ Spherical Voronoi Code

 import warnings
 import numpy as np
+import pykokkos as pk
 import scipy
 from . import _voronoi
 from scipy.spatial import cKDTree
@@ -312,7 +313,7 @@ class SphericalVoronoi:
         areas = self.radius * theta

         # Correct arcs which go the wrong way (single-hemisphere inputs)
-        signs = np.sign(np.einsum('ij,ij->i', arcs[:, 0],
+        signs = pk.sign(np.einsum('ij,ij->i', arcs[:, 0],
                                               self.vertices - self.center))
         indices = np.where(signs < 0)
         areas[indices] = 2 * np.pi * self.radius - areas[indices]
```