### PR TITLE
ENH: array + views for 1D abs ufunc

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -17,7 +17,9 @@ from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
                                  log2,
                                  log10,
                                  log1p,
-                                 sqrt)
+                                 sqrt,
+                                 abs,
+                                 absolute)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -1,3 +1,4 @@
+import copy
 import pykokkos as pk
 
 import numpy as np
@@ -299,6 +300,8 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
         (pk.log10, np.log10),
         (pk.log1p, np.log1p),
         (pk.sqrt, np.sqrt),
+        (pk.abs, np.abs),
+        (pk.absolute, np.absolute),
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
@@ -349,3 +352,22 @@ def test_caching():
         view[:] = np.arange(10, dtype=np.float32)
         actual = pk.reciprocal(view=view)
         assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("arr", [
+    np.array([4., -1., 17.7, -5.5]),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_abs_ufunc_1d(arr, pk_dtype, numpy_dtype):
+    expected = np.abs(arr, dtype=numpy_dtype)
+    view: pk.View1d = pk.View([arr.size], pk_dtype)
+    view[:] = copy.deepcopy(arr)
+    actual = pk.abs(view=view)
+    assert_allclose(actual, expected)
+    # check that the pykokkos ufunc can also directly
+    # handle a NumPy array argument
+    actual = pk.abs(view=copy.deepcopy(arr))
+    assert_allclose(actual, expected)


### PR DESCRIPTION
* add 1D ufunc for absolute value, but this time,
based on the experience integrating it into SciPy,
allow the pykokkos ufunc to directly accept both
views and native NumPy arrays

* when a native NumPy array is provided to `pk.abs()`
or `pk.absolute()` a new view is created with the data
in that NumPy array--this may also help avoid the in-place
operation issue if we like this idea?

* one problem I can't avoid at the moment when testing the
integration of this new ufunc into `scipy/spatial/_spherical_voronoi.py`
is that if we return a view when a NumPy array is provided,
the view can't quite fully mimic a NumPy array--for example,
in this case we can't call `.max()` on a pykokkos `view`
so I added an extra array coercion step in the diff below;
perhaps we should consider returning a NumPy array
when a NumPy array is provided, and a view when a view
is provided? possily even a keyword to control this, if it
doesn't get too complex..

* this diff passes Scipy tests when used with this branch
of pykokkos:

```diff
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -13,6 +13,7 @@ Spherical Voronoi Code

 import warnings
 import numpy as np
+import pykokkos as pk
 import scipy
 from . import _voronoi
 from scipy.spatial import cKDTree
@@ -31,7 +32,7 @@ def calculate_solid_angles(R):
     denominator = 1 + (np.einsum('ij,ij->i', R[:, 0], R[:, 1]) +
                        np.einsum('ij,ij->i', R[:, 1], R[:, 2]) +
                        np.einsum('ij,ij->i', R[:, 2], R[:, 0]))
-    return np.abs(2 * np.arctan2(numerator, denominator))
+    return pk.abs(2 * np.arctan2(numerator, denominator))

 class SphericalVoronoi:
@@ -189,7 +190,7 @@ class SphericalVoronoi:
             raise ValueError("Duplicate generators present.")

         radii = np.linalg.norm(self.points - self.center, axis=1)
-        max_discrepancy = np.abs(radii - self.radius).max()
+        max_discrepancy = np.asarray(pk.abs(radii - self.radius)).max()
         if max_discrepancy >= threshold * self.radius:
             raise ValueError("Radius inconsistent with generators.")

@@ -305,7 +306,7 @@ class SphericalVoronoi:

         # Calculate the angle subtended by arcs
         cosine = np.einsum('ij,ij->i', arcs[:, 0], arcs[:, 1])
-        sine = np.abs(np.linalg.det(arcs))
+        sine = pk.abs(np.linalg.det(arcs))
         theta = np.arctan2(sine, cosine)

         # Get areas using A = r * theta
```