### PR TITLE
ENH: arctan2 ufunc for arrays and views

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -17,7 +17,8 @@ from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
                                  log2,
                                  log10,
                                  log1p,
-                                 sqrt)
+                                 sqrt,
+                                 arctan2)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,5 +1,7 @@
 import pykokkos as pk
 
+import numpy as np
+
 
 @pk.workunit
 def reciprocal_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
@@ -208,3 +210,83 @@ def log1p(view):
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
     return view
+
+
+@pk.workunit
+def arctan2_impl_1d_double(tid: int,
+                           view_x1: pk.View1D[pk.double],
+                           view_x2: pk.View1D[pk.double],
+                           view_result: pk.View1D[pk.double],
+                           ):
+    view_result[tid] = atan2(view_x1[tid], view_x2[tid]) # type: ignore
+
+
+@pk.workunit
+def arctan2_impl_1d_float(tid: int,
+                           view_x1: pk.View1D[pk.float],
+                           view_x2: pk.View1D[pk.float],
+                           view_result: pk.View1D[pk.float],
+                           ):
+    view_result[tid] = atan2(view_x1[tid], view_x2[tid]) # type: ignore
+
+
+
+
+def arctan2(view_x1, view_x2):
+    """
+    Element-wise arc tangent of x1/x2 choosing the quadrant correctly.
+
+    Parameters
+    ----------
+    view_x1 : pykokkos view or NumPy array
+           Input view.
+
+    view_x2 : pykokkos view or NumPy array
+           Input view.
+
+    Returns
+    -------
+    y : pykokkos view or NumPy array
+
+    """
+    # TODO: what to do about the case where one argument is a view
+    # and the other is a NumPy array?
+    # TODO: add error handle for shape mismatches (and for broadcasting
+    # at some point)?
+    # TODO: what to do if the argument views/arrays have different types
+    # (i.e., one is float, the other double)?
+    if (isinstance(view_x1, (np.ndarray, np.generic)) and
+       (isinstance(view_x2, (np.ndarray, np.generic)))):
+        if np.issubdtype(view_x1.dtype, np.float64):
+            view_x1_loc: pk.View1d = pk.View([view_x1.size], pk.double)
+            view_x2_loc: pk.View1d = pk.View([view_x2.size], pk.double)
+        elif np.issubdtype(view_x1.dtype, np.float32):
+            view_x1_loc: pk.View1d = pk.View([view_x1.size], pk.float)
+            view_x2_loc: pk.View1d = pk.View([view_x2.size], pk.float)
+        view_x1_loc[:] = view_x1
+        view_x2_loc[:] = view_x2
+        view_x1 = view_x1_loc
+        view_x2 = view_x2_loc
+        numpy_arr = True
+    else:
+        numpy_arr = False
+    if (str(view_x1.dtype) == "DataType.double"
+        and str(view_x2.dtype) == "DataType.double"):
+        view_result: pk.View1d = pk.View([view_x1.size], pk.double)
+        pk.parallel_for(view_x1.shape[0],
+                        arctan2_impl_1d_double,
+                        view_x1=view_x1,
+                        view_x2=view_x2,
+                        view_result=view_result)
+    elif (str(view_x1.dtype) == "DataType.float"
+        and str(view_x2.dtype) == "DataType.float"):
+        view_result: pk.View1d = pk.View([view_x1.size], pk.float)
+        pk.parallel_for(view_x1.shape[0],
+                        arctan2_impl_1d_float,
+                        view_x1=view_x1,
+                        view_x2=view_x2,
+                        view_result=view_result)
+
+    if numpy_arr:
+        view_result = np.asarray(view_result)
+    return view_result


### PR DESCRIPTION
* add an `arctan2` ufunc with 1D support
that handles both direct NumPy array and
pykokkos view arguments

* add some initial regression tests for consistency
with NumPy behavior; some inline comments contain
deeper question/TODOs since this is the first
ufunc I've drafted that takes two view-like arguments
instead of just one

* in the spirit of keeping this integration-focused,
I verified that the SciPy test suite passes with the
following pykokkos substitution diff:

```diff
diff --git a/scipy/spatial/_spherical_voronoi.py b/scipy/spatial/_spherical_voronoi.py
index 42d557ddf..c0a8305de 100644
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -13,6 +13,7 @@ Spherical Voronoi Code

 import warnings
 import numpy as np
+import pykokkos as pk
 import scipy
 from . import _voronoi
 from scipy.spatial import cKDTree
@@ -31,7 +32,7 @@ def calculate_solid_angles(R):
     denominator = 1 + (np.einsum('ij,ij->i', R[:, 0], R[:, 1]) +
                        np.einsum('ij,ij->i', R[:, 1], R[:, 2]) +
                        np.einsum('ij,ij->i', R[:, 2], R[:, 0]))
-    return np.abs(2 * np.arctan2(numerator, denominator))
+    return np.abs(2 * pk.arctan2(numerator, denominator))

 class SphericalVoronoi:
@@ -306,7 +307,7 @@ class SphericalVoronoi:
         # Calculate the angle subtended by arcs
         cosine = np.einsum('ij,ij->i', arcs[:, 0], arcs[:, 1])
         sine = np.abs(np.linalg.det(arcs))
-        theta = np.arctan2(sine, cosine)
+        theta = pk.arctan2(sine, cosine)

         # Get areas using A = r * theta
         areas = self.radius * theta
```