### PR TITLE
ENH: add sum ufunc up to 3D

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -92,3 +92,5 @@ ignore_errors = True
 [mypy-pykokkos.core.translators.bindings]
 ignore_errors = True
 
+[mypy-pykokkos.lib.ufuncs]
+ignore_errors = True

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -12,12 +12,13 @@ from pykokkos.kokkos_manager import (
 )
 
 initialize()
-from pykokkos.lib.ufuncs import (reciprocal, # type: ignore
+from pykokkos.lib.ufuncs import (reciprocal,
                                  log,
                                  log2,
                                  log10,
                                  log1p,
-                                 sqrt)
+                                 sqrt,
+                                 sum)
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,5 +1,7 @@
 import pykokkos as pk
 
+import numpy as np
+
 
 @pk.workunit
 def reciprocal_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
@@ -208,3 +210,158 @@ def log1p(view):
     elif str(view.dtype) == "DataType.float":
         pk.parallel_for(view.shape[0], log1p_impl_1d_float, view=view)
     return view
+
+
+# TODO: why can't we use concise (but not lambda) functions
+# for reductions instead of this boilerplate-heavy infra
+# for reducing? see gh-51
+
+
+@pk.workload
+class SumImpl1dDouble:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.double = 0
+        self.view: pk.View1D[pk.double] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        acc += self.view[i]
+
+
+@pk.workload
+class SumImpl1dFloat:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.float = 0
+        self.view: pk.View1D[pk.float] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        acc += self.view[i]
+
+
+@pk.workload
+class SumImpl2dDouble:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.double = 0
+        self.view: pk.View2D[pk.double] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        for j in range(self.view.extent(1)):
+            acc += self.view[i][j]
+
+
+@pk.workload
+class SumImpl2dFloat:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.float = 0
+        self.view: pk.View2D[pk.float] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        for j in range(self.view.extent(1)):
+            acc += self.view[i][j]
+
+
+@pk.workload
+class SumImpl3dDouble:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.double = 0
+        self.view: pk.View3D[pk.double] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        for j in range(self.view.extent(1)):
+            for k in range(self.view.extent(2)):
+                acc += self.view[i][j][k]
+
+
+@pk.workload
+class SumImpl3dFloat:
+    def __init__(self, n, view):
+        self.N: int = n
+        self.total: pk.float = 0
+        self.view: pk.View3D[pk.float] = view
+
+    @pk.main
+    def run(self):
+        self.total = pk.parallel_reduce(self.N, self.sum)
+
+    @pk.workunit
+    def sum(self, i: int, acc: pk.Acc[pk.double]):
+        for j in range(self.view.extent(1)):
+            for k in range(self.view.extent(2)):
+                acc += self.view[i][j][k]
+
+
+def sum(view):
+    """
+    Sum of elements.
+
+    Parameters
+    ----------
+    view : pykokkos view or NumPy array
+
+    Returns
+    -------
+    y : pykokkos view or NumPy array or scalar
+
+    """
+    # TODO: support axis-aligned sums as NumPy does
+    # TODO: support `where` argument like NumPy does
+    if isinstance(view, (np.ndarray, np.generic)):
+        if np.issubdtype(view.dtype, np.float64):
+            view_loc = pk.View(view.shape, pk.double)
+        elif np.issubdtype(view.dtype, np.float32):
+            view_loc = pk.View(view.shape, pk.float)
+        view_loc[:] = view
+        view = view_loc
+    if str(view.dtype) == "DataType.double" and len(view.shape) == 1:
+        sum_inst = SumImpl1dDouble(n=view.shape[0],
+                                   view=view)
+    elif str(view.dtype) == "DataType.float" and len(view.shape) == 1:
+        sum_inst = SumImpl1dFloat(n=view.shape[0],
+                                  view=view)
+    elif str(view.dtype) == "DataType.double" and len(view.shape) == 2:
+        sum_inst = SumImpl2dDouble(n=view.shape[0],
+                                   view=view)
+    elif str(view.dtype) == "DataType.float" and len(view.shape) == 2:
+        sum_inst = SumImpl2dFloat(n=view.shape[0],
+                                  view=view)
+    elif str(view.dtype) == "DataType.double" and len(view.shape) == 3:
+        sum_inst = SumImpl3dDouble(n=view.shape[0],
+                                   view=view)
+    elif str(view.dtype) == "DataType.float" and len(view.shape) == 3:
+        # NOTE: I believe the Kokkos C++ docs suggest
+        # going parallel on the left-most dimension
+        # but I'm not sure if that is guaranteed to always
+        # be optimal?
+        sum_inst = SumImpl3dFloat(n=view.shape[0],
+                                  view=view)
+    pk.execute(pk.ExecutionSpace.Default, sum_inst)
+    return sum_inst.total

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -1,3 +1,4 @@
+import copy
 import pykokkos as pk
 
 import numpy as np
@@ -349,3 +350,30 @@ def test_caching():
         view[:] = np.arange(10, dtype=np.float32)
         actual = pk.reciprocal(view=view)
         assert_allclose(actual, expected)
+
+
+@pytest.mark.parametrize("arr", [
+    # arrays of different shapes
+    np.arange(20),
+    np.ones((5, 2)),
+    np.ones((5, 2, 2)),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+@pytest.mark.parametrize("arr_kind", [
+    # whether to use a pk view or NumPy array
+    "view", "arr",
+])
+def test_sum_ufunc(arr, pk_dtype, numpy_dtype, arr_kind):
+    expected = np.sum(arr, dtype=numpy_dtype)
+    if arr_kind == "view":
+        view = pk.View(arr.shape, pk_dtype)
+        view[:] = copy.deepcopy(arr.astype(numpy_dtype))
+    else:
+        view = copy.deepcopy(arr.astype(numpy_dtype))
+    actual = pk.sum(view=view)
+    assert_allclose(actual, expected)
+	# the original view/arr should be unchanged
+    assert_allclose(view, arr)


### PR DESCRIPTION
* add 1D-3D support for the `sum()` reduction ufunc;
this is likely the first example of a reduction ufunc
I've added so far

* satisfying the `mypy` type hint analysis caused some
tests to fail, so I'm suppressing the type hint checks
for the `ufuncs` module for now

* most comments/questions are in the source