### PR TITLE
WIP, ENH: support parallel runtests

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -19,10 +19,13 @@ pytest_args = []
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-t', '--specifictests', type=str)
+parser.add_argument('-n', '--numprocesses', type=int)
 args = parser.parse_args()
 
 if args.specifictests:
     pytest_args.append(args.specifictests)
+if args.numprocesses:
+    pytest_args.append(f"-n {args.numprocesses}")
 
 # force pytest to actually import
 # all the test modules directly


### PR DESCRIPTION
* add a `runtests.py` parallel option
following gh-59

Unfortunately a decent number of tests fail with i.e., `python runtests.py -n 10`, so this is still a WIP.

Sample traceback below, I'll try to check a bit later today

```
____________________________________________________________________________________________________________________________________ test_sign_1d_special_cases[in_arr0-float-float32] _____________________________________________________________________________________________________________________________________
[gw3] linux -- Python 3.10.4 /home/tyler/python_310_pykokkos_work/bin/python

in_arr = array([-5. ,  4.5,  nan], dtype=float32), pk_dtype = <class 'pykokkos.interface.data_types.float'>, numpy_dtype = <class 'numpy.float32'>

    @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
            (pk.double, np.float64),
            (pk.float, np.float32),
    ])
    @pytest.mark.parametrize("in_arr", [
        np.array([-5, 4.5, np.nan]),
        np.array([np.nan, np.nan, np.nan]),
    ])
    def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
        in_arr = in_arr.astype(numpy_dtype)
        view: pk.View1D = pk.View([in_arr.size], pk_dtype)
        view[:] = in_arr
        expected = np.sign(in_arr)
>       actual = pk.sign(view=view)

tests/test_ufuncs.py:390: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pykokkos/lib/ufuncs.py:257: in sign
    pk.parallel_for(view.shape[0], sign_impl_1d_float, view=view)
pykokkos/interface/parallel_dispatch.py:167: in parallel_for
    func, args = runtime_singleton.runtime.run_workunit(
pykokkos/core/runtime.py:85: in run_workunit
    return self.execute(workunit, module_setup, members, policy=policy, name=name, **kwargs)
pykokkos/core/runtime.py:119: in execute
    module = self.import_module(module_setup.name, module_setup.path)
pykokkos/core/runtime.py:148: in import_module
    module = importlib.util.module_from_spec(spec)
<frozen importlib._bootstrap>:571: in module_from_spec
    ???
<frozen importlib._bootstrap_external>:1176: in create_module
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

f = <built-in function create_dynamic>, args = (ModuleSpec(name='pk_cpp_pk_console_ufuncs_sign_impl_1d_float_OpenMP_kernel_cpython_310_x86_64_linux_gnu_so', loader=<.../github_projects/pykokkos/pk_cpp/pk_console/ufuncs_sign_impl_1d_float/OpenMP/kernel.cpython-310-x86_64-linux-gnu.so'),), kwds = {}

>   ???
E   ImportError: /home/tyler/github_projects/pykokkos/pk_cpp/pk_console/ufuncs_sign_impl_1d_float/OpenMP/kernel.cpython-310-x86_64-linux-gnu.so: cannot open shared object file: No such file or directory

<frozen importlib._bootstrap>:241: ImportError
```