### PR TITLE
BUG: parallel-safe pykokkos

### DIFF
--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -140,7 +140,12 @@ class ModuleSetup:
         """
 
         filename: str = metadata.path.split("/")[-1].split(".")[0]
-        dirname: str = f"{filename}_{metadata.name}"
+        # the compilation paths do not have concurrent safety without a unique
+        # identifier because i.e., compilation units can share
+        # the same module/class; try using the memory loc of the Python
+        # metadata object
+        mem_id = id(metadata)
+        dirname: str = f"{filename}_{metadata.name}_{mem_id}"
 
         return self.get_main_dir(main) / Path(dirname)
 


### PR DESCRIPTION
* the current `develop` branch appears to not be parallel
safe as described at https://github.com/kokkos/pykokkos/pull/60#issuecomment-1221115957

* this branch allows pykokkos to compile/run code both
in serial and in parallel by providing genuinely unique
identifiers (file paths) to each "compilation unit"; careful though,
this will slow down the serial execution time for the testsuite
substantially, probably because it removes reuse in favor
of safety from a compilation standpoint--there's probably an approach
that is both fast and safe, and I'm certainly open to that, but
I'd also argue that safe and slow > (parallel) unsafe and fast

* combined with gh-60, this allows:
  - `OMP_NUM_THREADS=1 python runtests.py -n 10`
  - `123 passed, 9 skipped, 9 xfailed, 16 warnings in 92.10s (0:01:32)`
  - that's more than twice as fast as the serial test run on `develop` on the same machine
  - `python runtests.py`
  - `123 passed, 9 skipped, 9 xfailed, 16 warnings in 212.40s (0:03:32)` (`3:18` with `OMP_NUM_THREADS=1`)
  - however, this branch slows down the serial test run a lot, to 11.5
    minutes!

* of course, you'd probably have to thoroughly test `OMP_NUM_THREADS`
  values and so on to benchmark the hierarchical parallelism situation
  to determine scenarios where you'd even want to use "parallel pykokkos,"
  but I certainly think we should try to be "safe" for concurrent usage
  so that we don't impose a certain model of concurrency on our
  consumers