### PR TITLE
CI: pin array API suite

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -39,6 +39,8 @@ jobs:
           cd /tmp
           git clone https://github.com/data-apis/array-api-tests.git
           cd array-api-tests
+          # see gh-63 for the commit pin
+          git checkout 4d9d7b4b73c
           git submodule update --init
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos


### PR DESCRIPTION
* temporarily pin the array API testsuite version used
in CI to avoid gh-63; I tested with the
[`act`](https://github.com/nektos/act) tool locally and it seems to pass

* we can unpin when there's an upstream fix, though we may
want to stay pinned for some time and only occasionally
bump to the latest version after testing it