### PR TITLE
ENH: pk.ones() to API standard

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -46,9 +46,10 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  exp,
                                  exp2,
                                 isinf,
-                                isnan)
+                                isnan,
+                                equal)
 from pykokkos.lib.info import iinfo, finfo
-from pykokkos.lib.create import zeros
+from pykokkos.lib.create import zeros, ones
 from pykokkos.lib.util import all, any
 from pykokkos.lib.constants import e, pi, inf, nan
 

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -181,7 +181,7 @@ class ViewType:
 class View(ViewType):
     def __init__(
         self,
-        shape: Tuple[int],
+        shape: Union[List[int], Tuple[int]],
         dtype: Union[DataTypeClass, type] = real,
         space: MemorySpace = MemorySpace.MemorySpaceDefault,
         layout: Layout = Layout.LayoutDefault,
@@ -191,7 +191,7 @@ class View(ViewType):
         """
         View constructor.
 
-        :param shape: the shape of the view as a tuple of integers
+        :param shape: the shape of the view as a list or tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -256,7 +256,7 @@ class View(ViewType):
         """
         Initialize the view
 
-        :param shape: the shape of the view as a tuple of integers
+        :param shape: the shape of the view as a list or tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -265,8 +265,6 @@ class View(ViewType):
         """
 
         self.shape: Tuple[int] = tuple(shape)
-        if self.shape == (0,):
-            self.shape = ()
         self.size: int = math.prod(shape)
         self.dtype: Optional[DataType] = self._get_type(dtype)
         if self.dtype is None:
@@ -286,9 +284,6 @@ class View(ViewType):
         self.layout: Layout = layout
         self.trait: Trait = trait
 
-        # TODO: if ufuncs stop inspecting
-        # type "strings," we should be able to
-        # purge these mappings
         if self.dtype == pk.float:
             self.dtype = DataType.float
         elif self.dtype == pk.double:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -22,7 +22,7 @@ from .data_types import (
     int16, int32, int64,
     uint8,
     uint16, uint32, uint64,
-    double
+    double, float64,
 )
 from .layout import get_default_layout, Layout
 from .memory_space import get_default_memory_space, MemorySpace
@@ -138,8 +138,14 @@ class ViewType:
         :returns: the length of the first dimension
         """
 
+        # NOTE: careful with 0-D treatments and __bool__
+        # related handling; you can have shape () and
+        # still be True for example...
         if len(self.shape) == 0:
-            return 0
+            if self.data != 0:
+                return 1
+            else:
+                return 0
         return self.shape[0]
 
     def __iter__(self) -> Iterator:
@@ -149,7 +155,11 @@ class ViewType:
         :returns: an iterator over the data
         """
 
-        return (n for n in self.data)
+        if self.data.ndim > 0:
+            return (n for n in self.data)
+        else:
+            # 0-D case returns empty generator
+            return zip()
 
     def __str__(self) -> str:
         """
@@ -171,7 +181,7 @@ class ViewType:
 class View(ViewType):
     def __init__(
         self,
-        shape: List[int],
+        shape: Tuple[int],
         dtype: Union[DataTypeClass, type] = real,
         space: MemorySpace = MemorySpace.MemorySpaceDefault,
         layout: Layout = Layout.LayoutDefault,
@@ -181,7 +191,7 @@ class View(ViewType):
         """
         View constructor.
 
-        :param shape: the shape of the view as a list of integers
+        :param shape: the shape of the view as a tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -246,7 +256,7 @@ class View(ViewType):
         """
         Initialize the view
 
-        :param shape: the shape of the view as a list of integers
+        :param shape: the shape of the view as a tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -332,7 +342,10 @@ class View(ViewType):
 
 
     def __hash__(self):
-        hash_value = hash(self.array)
+        try:
+            hash_value = hash(self.array)
+        except TypeError:
+            hash_value = hash(self.array.data.tobytes())
         return hash_value
 
 
@@ -460,9 +473,9 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     elif np_dtype is np.float32:
         dtype = DataType.float # PyKokkos float
     elif np_dtype is np.float64:
-        dtype = double
+        dtype = float64
     elif np_dtype is np.bool_:
-        dtype = int16
+        dtype = uint16
     else:
         raise RuntimeError(f"ERROR: unsupported numpy datatype {np_dtype}")
 
@@ -482,7 +495,13 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     # temporary/terrible hack here for array API testing..
     if array.ndim == 0:
         ret_list = ()
-        array = np.array(array, dtype=np_dtype)
+        if np_dtype == np.bool_:
+            if array == 1:
+                array = np.array(1, dtype=np.uint8)
+            else:
+                array = np.array(0, dtype=np.uint8)
+        else:
+            array = np.array(array, dtype=np_dtype)
     else:
         ret_list = list((array.shape))
 
@@ -552,8 +571,6 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
         view = pk.View([1], dtype=dtype)
         view[:] = obj
         return view
-    if "bool" in str(dtype):
-        dtype = np.bool_
     if dtype is not None:
         arr = np.asarray(obj, dtype=dtype.np_equiv)
     else:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -286,6 +286,9 @@ class View(ViewType):
         self.layout: Layout = layout
         self.trait: Trait = trait
 
+        # TODO: if ufuncs stop inspecting
+        # type "strings," we should be able to
+        # purge these mappings
         if self.dtype == pk.float:
             self.dtype = DataType.float
         elif self.dtype == pk.double:
@@ -475,7 +478,7 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     elif np_dtype is np.float64:
         dtype = float64
     elif np_dtype is np.bool_:
-        dtype = uint16
+        dtype = uint8
     else:
         raise RuntimeError(f"ERROR: unsupported numpy datatype {np_dtype}")
 

--- a/pykokkos/lib/create.py
+++ b/pykokkos/lib/create.py
@@ -2,3 +2,15 @@ import pykokkos as pk
 
 def zeros(shape, *, dtype=None, device=None):
     return pk.View([*shape], dtype=dtype)
+
+
+def ones(shape, *, dtype=None, device=None):
+    if dtype is None:
+        # NumPy also defaults to a double for ones()
+        dtype = pk.float64
+    view: pk.View = pk.View([*shape], dtype=dtype)
+    view[:] = 1
+    if shape == (0,):
+        view.shape = (0,)
+    view.shape = tuple(view.shape)
+    return view

--- a/pykokkos/lib/create.py
+++ b/pykokkos/lib/create.py
@@ -10,7 +10,4 @@ def ones(shape, *, dtype=None, device=None):
         dtype = pk.float64
     view: pk.View = pk.View([*shape], dtype=dtype)
     view[:] = 1
-    if shape == (0,):
-        view.shape = (0,)
-    view.shape = tuple(view.shape)
     return view

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1437,7 +1437,7 @@ def equal_impl_1d_double(tid: int,
                          view1: pk.View1D[pk.double],
                          view2: pk.View1D[pk.double],
                          view2_size: int,
-                         view_result: pk.View1D[pk.uint16]):
+                         view_result: pk.View1D[pk.uint8]):
     view2_idx: int = 0
     if view2_size == 1:
         view2_idx = 0
@@ -1454,7 +1454,7 @@ def equal_impl_1d_uint16(tid: int,
                          view1: pk.View1D[pk.uint16],
                          view2: pk.View1D[pk.uint16],
                          view2_size: int,
-                         view_result: pk.View1D[pk.uint16]):
+                         view_result: pk.View1D[pk.uint8]):
     view2_idx: int = 0
     if view2_size == 1:
         view2_idx = 0
@@ -1471,7 +1471,7 @@ def equal_impl_1d_int16(tid: int,
                          view1: pk.View1D[pk.int16],
                          view2: pk.View1D[pk.int16],
                          view2_size: int,
-                         view_result: pk.View1D[pk.uint16]):
+                         view_result: pk.View1D[pk.uint8]):
     view2_idx: int = 0
     if view2_size == 1:
         view2_idx = 0
@@ -1488,7 +1488,7 @@ def equal_impl_1d_int32(tid: int,
                          view1: pk.View1D[pk.int32],
                          view2: pk.View1D[pk.int32],
                          view2_size: int,
-                         view_result: pk.View1D[pk.uint16]):
+                         view_result: pk.View1D[pk.uint8]):
     view2_idx: int = 0
     if view2_size == 1:
         view2_idx = 0
@@ -1505,7 +1505,7 @@ def equal_impl_1d_int64(tid: int,
                          view1: pk.View1D[pk.int64],
                          view2: pk.View1D[pk.int64],
                          view2_size: int,
-                         view_result: pk.View1D[pk.uint16]):
+                         view_result: pk.View1D[pk.uint8]):
     view2_idx: int = 0
     if view2_size == 1:
         view2_idx = 0
@@ -1530,33 +1530,7 @@ def equal(view1, view2):
             # scalar (i.e., matching number of columns)
             raise ValueError("view1 and view2 have incompatible shapes")
 
-    # TODO: something more appropriate than uint16 as a proxy
-    # for the bool type? (a shorter integer like uint8
-    # at least?)
-    view_result = pk.View([*view1.shape], dtype=pk.uint16)
-
-    # NOTE: the blocks below are asymmetric on view1 vs view2,
-    # and also quite awkward--they evolved from making the array API
-    # test_ones() test pass, but need refinement or removal eventually
-    try:
-        if isinstance(view2.array, np.ndarray):
-            if view2.size <= 1:
-                new_shape = (1,)
-            else:
-                new_shape = view2.shape
-            view2r = pk.View([*new_shape], dtype=view2.dtype)
-            view2r[:] = view2.array
-            view2 = view2r
-    except AttributeError:
-        pass
-    try:
-        if isinstance(view1.array, np.ndarray):
-            if view1.shape == () or view1.shape == (0,):
-                view1r = pk.View([1], dtype=view1.dtype)
-                view1r[:] = view1.array
-                view1 = view1r
-    except AttributeError:
-        pass
+    view_result = pk.View([*view1.shape], dtype=pk.uint8)
 
     if ("double" in str(view1.dtype) or "float64" in str(view1.dtype) and
        ("double" in str(view2.dtype) or "float64" in str(view2.dtype))):

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1431,8 +1431,8 @@ def isinf(view):
                         view=view,
                         out=out)
     return out
-=======
-=======
+
+@pk.workunit
 def equal_impl_1d_double(tid: int,
                          view1: pk.View1D[pk.double],
                          view2: pk.View1D[pk.double],

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1,5 +1,7 @@
 import pykokkos as pk
 
+import numpy as np
+
 
 @pk.workunit
 def reciprocal_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
@@ -1429,3 +1431,172 @@ def isinf(view):
                         view=view,
                         out=out)
     return out
+=======
+=======
+def equal_impl_1d_double(tid: int,
+                         view1: pk.View1D[pk.double],
+                         view2: pk.View1D[pk.double],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint16]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_uint16(tid: int,
+                         view1: pk.View1D[pk.uint16],
+                         view2: pk.View1D[pk.uint16],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint16]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int16(tid: int,
+                         view1: pk.View1D[pk.int16],
+                         view2: pk.View1D[pk.int16],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint16]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int32(tid: int,
+                         view1: pk.View1D[pk.int32],
+                         view2: pk.View1D[pk.int32],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint16]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int64(tid: int,
+                         view1: pk.View1D[pk.int64],
+                         view2: pk.View1D[pk.int64],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint16]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+def equal(view1, view2):
+    # TODO: write even more dispatching for cases where view1 and view2
+    # have different, but comparable, types (like float32 vs. float64?)
+    # this may "explode" without templating
+
+    if sum(view1.shape) == 0 or sum(view2.shape) == 0:
+        return np.empty(shape=(0,))
+
+    if view1.shape != view2.shape:
+        if not view1.size <= 1 and not view2.size <= 1:
+            # TODO: supporting __eq__ over broadcasted shapes beyond
+            # scalar (i.e., matching number of columns)
+            raise ValueError("view1 and view2 have incompatible shapes")
+
+    # TODO: something more appropriate than uint16 as a proxy
+    # for the bool type? (a shorter integer like uint8
+    # at least?)
+    view_result = pk.View([*view1.shape], dtype=pk.uint16)
+
+    # NOTE: the blocks below are asymmetric on view1 vs view2,
+    # and also quite awkward--they evolved from making the array API
+    # test_ones() test pass, but need refinement or removal eventually
+    try:
+        if isinstance(view2.array, np.ndarray):
+            if view2.size <= 1:
+                new_shape = (1,)
+            else:
+                new_shape = view2.shape
+            view2r = pk.View([*new_shape], dtype=view2.dtype)
+            view2r[:] = view2.array
+            view2 = view2r
+    except AttributeError:
+        pass
+    try:
+        if isinstance(view1.array, np.ndarray):
+            if view1.shape == () or view1.shape == (0,):
+                view1r = pk.View([1], dtype=view1.dtype)
+                view1r[:] = view1.array
+                view1 = view1r
+    except AttributeError:
+        pass
+
+    if ("double" in str(view1.dtype) or "float64" in str(view1.dtype) and
+       ("double" in str(view2.dtype) or "float64" in str(view2.dtype))):
+        pk.parallel_for(view1.size,
+                        equal_impl_1d_double,
+                        view1=view1,
+                        view2=view2,
+                        view2_size=view2.size,
+                        view_result=view_result)
+    elif (("uint16" in str(view1.dtype) or "bool" in str(view1.dtype)) and
+          ("uint16" in str(view2.dtype) or "bool" in str(view2.dtype))):
+        pk.parallel_for(view1.size,
+                        equal_impl_1d_uint16,
+                        view1=view1,
+                        view2=view2,
+                        view2_size=view2.size,
+                        view_result=view_result)
+    elif "int16" in str(view1.dtype) and "int16" in str(view1.dtype):
+        pk.parallel_for(view1.size,
+                        equal_impl_1d_int16,
+                        view1=view1,
+                        view2=view2,
+                        view2_size=view2.size,
+                        view_result=view_result)
+    elif "int32" in str(view1.dtype) and "int32" in str(view1.dtype):
+        pk.parallel_for(view1.size,
+                        equal_impl_1d_int32,
+                        view1=view1,
+                        view2=view2,
+                        view2_size=view2.size,
+                        view_result=view_result)
+    elif "int64" in str(view1.dtype) and "int64" in str(view1.dtype):
+        pk.parallel_for(view1.size,
+                        equal_impl_1d_int64,
+                        view1=view1,
+                        view2=view2,
+                        view2_size=view2.size,
+                        view_result=view_result)
+    else:
+        # TODO: include the view types in the error message
+        raise NotImplementedError("equal ufunc not implemented for this comparison")
+
+    return view_result

--- a/pykokkos/lib/util.py
+++ b/pykokkos/lib/util.py
@@ -13,7 +13,7 @@ def all(x, /, *, axis=None, keepdims=False):
     elif x == False:
         return False
     np_result = np.all(x)
-    ret_val = pk.View(pk.from_numpy(np.all(x)))
+    ret_val = pk.from_numpy(np_result)
     return ret_val
 
 


### PR DESCRIPTION
Fixes #70

* implement `pk.ones()` such that
`array_api_tests/test_creation_functions.py::test_ones` passes

* the Python array API standard `test_ones()` makes use
of `pk.equal()`, which wasn't implemented, so an early-stage
implementation is added here (which should help later on as well,
since the need to occasionally do `view1 == view2` should be
obvious)

* this is no doubt a bit of a "hack," especially in terms
of full-featured broadcasting for `pk.equal`, which is currently only
supported for "scalar" broadcasting in my work here

* I was a bit surprised that I only needed to add limited 1D
support for `pk.equal()`, but I imagine the code there will grow
substantially to support more scenarios/remove hacks in the future

* note that this branch also borrows some of the typing
changes from gh-67 (and improves on them slightly I think)

* special shims are present for some `0-D` type scenarios,
and for now I've doubled down on the adoption of an unsigned
integer type as a proxy for a `bool` array--I suggest we at least
use a shorter width type for this in the future though, once
the pykokkos-base bindings are merged

* although I'm leaning on the Python array API standard tests here,
I did check that i.e., this works:

```python
import pykokkos as pk

def main():
    a = pk.ones((3, 3))
    print(a)

if __name__ == "__main__":
    main()
```

```
[[1. 1. 1.]
 [1. 1. 1.]
 [1. 1. 1.]]
```

* note, however, that the hook-in of `pk.equal()` to `__equal__`
wasn't the focus of this work (since the array API tests simply
call `pk.equal()` for the isolated test I was working on), so
for now:

```python
import pykokkos as pk

def main():
    a = pk.ones((3,))
    b = pk.ones((3,))
    result = a == b
    print(result)
    result2 = pk.equal(a, b)
    print(result2)

if __name__ == "__main__":
    main()
```

Produces:

```
False
[1 1 1]
```

* what we really want is `True` and `[True True True]`,
but the latter isn't too bad at least--the `1` values are
a proxy for truth in the `pk.uint16` type we're using
in place of `bool` for now; I suggest we delay the hook-in
to `__equal__` for now...