### PR TITLE
CI: add Python 3.11 RC1 to CI

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-rc.1"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +30,11 @@ jobs:
           cd /tmp
           git clone https://github.com/kokkos/pykokkos-base.git
           cd pykokkos-base
+          git submodule update --init
+          cd external/pybind11
+          git fetch --tags
+          git checkout v2.10.0
+          cd ../../
           python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF
       - name: Install pykokkos
         run: |


### PR DESCRIPTION
* Python `3.11` RC1 is ABI stable, so might
as well test against it

* we should be able to remove the custom `pybind11`
submodule checkout once we update upstream per:
https://github.com/kokkos/pykokkos-base/issues/44