### PR TITLE
CI: simplify pybind11

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -30,11 +30,6 @@ jobs:
           cd /tmp
           git clone https://github.com/kokkos/pykokkos-base.git
           cd pykokkos-base
-          git submodule update --init
-          cd external/pybind11
-          git fetch --tags
-          git checkout v2.10.0
-          cd ../../
           python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF
       - name: Install pykokkos
         run: |


### PR DESCRIPTION
* following the upstream merge of https://github.com/kokkos/pykokkos-base/pull/46
we should no longer need to manually update the `pybind11` submodule
within `pykokkos-base`