### PR TITLE
ENH: add int8/uint8

### DIFF
--- a/pykokkos/core/cppast/decl.py
+++ b/pykokkos/core/cppast/decl.py
@@ -15,10 +15,12 @@ class BuiltinType(Enum):
     BOOL = "bool"
     FLOAT = "float"
 
+    INT8 = "int8_t"
     INT16 = "int16_t"
     INT32 = "int32_t"
     INT64 = "int64_t"
 
+    UINT8 = "uint8_t"
     UINT16 = "uint16_t"
     UINT32 = "uint32_t"
     UINT64 = "uint64_t"

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -20,9 +20,11 @@ allowed_types: Dict[str, str] = {
 
 # Maps from the DataType enum to cppast
 view_dtypes: Dict[str, Union[cppast.BuiltinType, str]] = {
+    "int8": cppast.BuiltinType.INT8,
     "int16": cppast.BuiltinType.INT16,
     "int32": cppast.BuiltinType.INT32,
     "int64": cppast.BuiltinType.INT64,
+    "uint8": cppast.BuiltinType.UINT8,
     "uint16": cppast.BuiltinType.UINT16,
     "uint32": cppast.BuiltinType.UINT32,
     "uint64": cppast.BuiltinType.UINT64,
@@ -290,8 +292,8 @@ def cpp_view_type(
         parameter: str = s.serialize(t)
 
         if parameter in ("int", "double", "float",
-                            "int16_t", "int32_t", "int64_t",
-                            "uint16_t", "uint32_t", "uint64_t"):
+                            "int8_t", "int16_t", "int32_t", "int64_t",
+                            "uint8_t", "uint16_t", "uint32_t", "uint64_t"):
             datatype: str = parameter + "*" * rank
             params["dtype"] = datatype
 

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -12,7 +12,9 @@ from .atomic.atomic_op import (
 from .bin_sort import BinSort, BinOp, BinOp1D, BinOp3D
 from .data_types import (
     DataType, DataTypeClass,
+    int8,
     int16, int32, int64,
+    uint8,
     uint16, uint32, uint64,
     float, double, real,
     float32, float64, bool,

--- a/pykokkos/interface/data_types.py
+++ b/pykokkos/interface/data_types.py
@@ -5,9 +5,11 @@ import numpy as np
 
 
 class DataType(Enum):
+    int8 = kokkos.int8
     int16 = kokkos.int16
     int32 = kokkos.int32
     int64 = kokkos.int64
+    uint8 = kokkos.uint8
     uint16 = kokkos.uint16
     uint32 = kokkos.uint32
     uint64 = kokkos.uint64
@@ -29,6 +31,12 @@ class DataType(Enum):
 class DataTypeClass:
     pass
 
+
+class uint8(DataTypeClass):
+    value = kokkos.uint8
+
+class int8(DataTypeClass):
+    value = kokkos.int8
 
 class int16(DataTypeClass):
     value = kokkos.int16

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -18,7 +18,9 @@ import pykokkos.kokkos_manager as km
 from .data_types import (
     DataType, DataTypeClass,
     real,
+    int8,
     int16, int32, int64,
+    uint8,
     uint16, uint32, uint64,
     double
 )
@@ -416,12 +418,16 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     dtype: DataTypeClass
     np_dtype = array.dtype.type
 
+    if np_dtype is np.int8:
+        dtype = int8
     if np_dtype is np.int16:
         dtype = int16
     elif np_dtype is np.int32:
         dtype = int32
     elif np_dtype is np.int64:
         dtype = int64
+    elif np_dtype is np.uint8:
+        dtype = uint8
     elif np_dtype is np.uint16:
         dtype = uint16
     elif np_dtype is np.uint32:
@@ -469,12 +475,16 @@ def from_cupy(array) -> ViewType:
 
     np_dtype = array.dtype.type
 
+    if np_dtype is np.int8:
+        ctype = ctypes.c_int8
     if np_dtype is np.int16:
         ctype = ctypes.c_int16
     elif np_dtype is np.int32:
         ctype = ctypes.c_int32
     elif np_dtype is np.int64:
         ctype = ctypes.c_int64
+    elif np_dtype is np.uint8:
+        ctype = ctypes.c_uint8
     elif np_dtype is np.uint16:
         ctype = ctypes.c_uint16
     elif np_dtype is np.uint32:


### PR DESCRIPTION
* add the `int8` and `uint8` types following
the upstream PRs:
https://github.com/kokkos/pykokkos-base/pull/47
https://github.com/kokkos/pykokkos-base/pull/43

* these are required for array API conformance per:
https://data-apis.org/array-api/latest/API_specification/data_types.html

* I was also thinking `uint8` may be a suitable proxy
for `bool` one way or another, unless we can easily use
an even smaller custom type for that