### PR TITLE
Multiple arithmetic, logical, and trigonometric ufuncs

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -30,7 +30,21 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  fmod,
                                  square,
                                  greater,
-                                 logaddexp)
+                                 logaddexp,
+                                 true_divide,
+                                 logaddexp2,
+                                 floor_divide,
+                                 sin,
+                                 cos,
+                                 tan,
+                                 logical_and,
+                                 logical_or,
+                                 logical_xor,
+                                 logical_not,
+                                 fmax,
+                                 fmin,
+                                 exp,
+                                 exp2)
 from pykokkos.lib.info import iinfo, finfo
 from pykokkos.lib.create import zeros
 from pykokkos.lib.util import all, any

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -86,6 +86,8 @@ math_functions: Set = {
     "expm1",
     "fabs",
     "floor",
+    "fmax",
+    "fmin"
     "fmod",
     "hypot",
     "isfinite",

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -87,7 +87,7 @@ math_functions: Set = {
     "fabs",
     "floor",
     "fmax",
-    "fmin"
+    "fmin",
     "fmod",
     "hypot",
     "isfinite",

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -948,7 +948,7 @@ def sin_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.flo
 
 def sin(view):
     """
-    Element-wise trignometric sine of the view
+    Element-wise trigonometric sine of the view
 
     Parameters
     ----------
@@ -982,7 +982,7 @@ def cos_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.flo
 
 def cos(view):
     """
-    Element-wise trignometric cosine of the view
+    Element-wise trigonometric cosine of the view
 
     Parameters
     ----------
@@ -1217,12 +1217,12 @@ def logical_not(view):
 
 
 @pk.workunit
-def fmax_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def fmax_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = fmax(viewA[tid], viewB[tid])
 
 
 @pk.workunit
-def fmax_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def fmax_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = fmax(viewA[tid], viewB[tid])
 
 
@@ -1239,12 +1239,12 @@ def fmax(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
             viewA.shape[0],
             fmax_impl_1d_double,
@@ -1253,6 +1253,7 @@ def fmax(viewA, viewB):
             out=out)
 
     elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        out = pk.View([viewA.shape[0]], pk.float)
         pk.parallel_for(
             viewA.shape[0],
             fmax_impl_1d_float,
@@ -1265,12 +1266,12 @@ def fmax(viewA, viewB):
 
 
 @pk.workunit
-def fmin_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def fmin_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = fmin(viewA[tid], viewB[tid])
 
 
 @pk.workunit
-def fmin_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def fmin_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = fmin(viewA[tid], viewB[tid])
 
 
@@ -1287,12 +1288,12 @@ def fmin(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
             viewA.shape[0],
             fmin_impl_1d_double,
@@ -1301,6 +1302,7 @@ def fmin(viewA, viewB):
             out=out)
 
     elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        out = pk.View([viewA.shape[0]], pk.float)
         pk.parallel_for(
             viewA.shape[0],
             fmin_impl_1d_float,

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -409,9 +409,11 @@ def subtract(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def matmul_impl_1d_double(tid: int, acc: pk.Acc[pk.double], viewA: pk.View1D[pk.double], viewB: pk.View2D[pk.double]):
     acc += viewA[tid] * viewB[0][tid]
+
 
 @pk.workunit
 def matmul_impl_1d_float(tid: int, acc: pk.Acc[pk.float], viewA: pk.View1D[pk.float], viewB: pk.View2D[pk.float]):
@@ -453,9 +455,11 @@ def matmul(viewA, viewB):
     else:
         raise RuntimeError("Incompatible Types")
 
+
 @pk.workunit
 def divide_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = viewA[tid] / viewB[tid]
+
 
 @pk.workunit
 def divide_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -501,9 +505,11 @@ def divide(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def negative_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = view[tid] * -1
+
 
 @pk.workunit
 def negative_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -532,9 +538,11 @@ def negative(view):
         pk.parallel_for(view.shape[0], negative_impl_1d_float, view=view, out=out)
     return out
 
+
 @pk.workunit
 def positive_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = view[tid]
+
 
 @pk.workunit
 def positive_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -568,6 +576,7 @@ def positive(view):
 @pk.workunit
 def power_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = pow(viewA[tid], viewB[tid])
+
 
 @pk.workunit
 def power_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -617,6 +626,7 @@ def power(viewA, viewB):
 @pk.workunit
 def fmod_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = fmod(viewA[tid], viewB[tid])
+
 
 @pk.workunit
 def fmod_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -668,6 +678,7 @@ def fmod(viewA, viewB):
 def square_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = view[tid] * view[tid]
 
+
 @pk.workunit
 def square_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = view[tid] * view[tid]
@@ -706,9 +717,11 @@ def square(view):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def greater_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = viewA[tid] > viewB[tid]
+
 
 @pk.workunit
 def greater_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
@@ -752,9 +765,11 @@ def greater(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def logaddexp_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double],):
     out[tid] = log(exp(viewA[tid]) + exp(viewB[tid]))
+
 
 @pk.workunit
 def logaddexp_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float],):
@@ -825,6 +840,7 @@ def true_divide(viewA, viewB):
 def logaddexp2_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double],):
     out[tid] = log2(pow(2, viewA[tid]) + pow(2, viewB[tid]))
 
+
 @pk.workunit
 def logaddexp2_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float],):
     out[tid] = log2(pow(2, viewA[tid]) + pow(2, viewB[tid]))
@@ -873,6 +889,7 @@ def logaddexp2(viewA, viewB):
 @pk.workunit
 def floor_divide_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = viewA[tid] // viewB[tid]
+
 
 @pk.workunit
 def floor_divide_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
@@ -923,9 +940,11 @@ def floor_divide(viewA, viewB):
 def sin_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = sin(view[tid])
 
+
 @pk.workunit
 def sin_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = sin(view[tid])
+
 
 def sin(view):
     """
@@ -950,13 +969,16 @@ def sin(view):
         pk.parallel_for(view.shape[0], sin_impl_1d_float, view=view, out=out)
     return out
 
+
 @pk.workunit
 def cos_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = cos(view[tid])
 
+
 @pk.workunit
 def cos_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = cos(view[tid])
+
 
 def cos(view):
     """
@@ -981,13 +1003,16 @@ def cos(view):
         pk.parallel_for(view.shape[0], cos_impl_1d_float, view=view, out=out)
     return out
 
+
 @pk.workunit
 def tan_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = tan(view[tid])
 
+
 @pk.workunit
 def tan_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = tan(view[tid])
+
 
 def tan(view):
     """
@@ -1012,9 +1037,11 @@ def tan(view):
         pk.parallel_for(view.shape[0], tan_impl_1d_float, view=view, out=out)
     return out
 
+
 @pk.workunit
 def logical_and_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = viewA[tid] and viewB[tid]
+
 
 @pk.workunit
 def logical_and_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
@@ -1058,9 +1085,11 @@ def logical_and(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def logical_or_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = viewA[tid] or viewB[tid]
+
 
 @pk.workunit
 def logical_or_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
@@ -1104,9 +1133,11 @@ def logical_or(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def logical_xor_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = bool(viewA[tid]) ^ bool(viewB[tid])
+
 
 @pk.workunit
 def logical_xor_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
@@ -1150,13 +1181,16 @@ def logical_xor(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def logical_not_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = not view[tid]
 
+
 @pk.workunit
 def logical_not_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = not view[tid]
+
 
 def logical_not(view):
     """
@@ -1181,13 +1215,16 @@ def logical_not(view):
         pk.parallel_for(view.shape[0], logical_not_impl_1d_float, view=view, out=out)
     return out
 
+
 @pk.workunit
 def fmax_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = fmax(viewA[tid], viewB[tid])
 
+
 @pk.workunit
 def fmax_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
     out[tid] = fmax(viewA[tid], viewB[tid])
+
 
 def fmax(viewA, viewB):
     """
@@ -1226,13 +1263,16 @@ def fmax(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def fmin_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
     out[tid] = fmin(viewA[tid], viewB[tid])
 
+
 @pk.workunit
 def fmin_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
     out[tid] = fmin(viewA[tid], viewB[tid])
+
 
 def fmin(viewA, viewB):
     """
@@ -1271,13 +1311,16 @@ def fmin(viewA, viewB):
         raise RuntimeError("Incompatible Types")
     return out
 
+
 @pk.workunit
 def exp_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = exp(view[tid])
 
+
 @pk.workunit
 def exp_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = exp(view[tid])
+
 
 def exp(view):
     """
@@ -1307,9 +1350,11 @@ def exp(view):
 def exp2_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
     out[tid] = pow(2, view[tid])
 
+
 @pk.workunit
 def exp2_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
     out[tid] = pow(2, view[tid])
+
 
 def exp2(view):
     """

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -719,12 +719,12 @@ def square(view):
 
 
 @pk.workunit
-def greater_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def greater_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] > viewB[tid]
 
 
 @pk.workunit
-def greater_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def greater_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] > viewB[tid]
 
 
@@ -741,11 +741,11 @@ def greater(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view (uint8)
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
+    out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
             viewA.shape[0],
@@ -1039,12 +1039,12 @@ def tan(view):
 
 
 @pk.workunit
-def logical_and_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def logical_and_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] and viewB[tid]
 
 
 @pk.workunit
-def logical_and_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def logical_and_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] and viewB[tid]
 
 
@@ -1061,11 +1061,11 @@ def logical_and(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view (uint8)
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
+    out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
             viewA.shape[0],
@@ -1087,12 +1087,12 @@ def logical_and(viewA, viewB):
 
 
 @pk.workunit
-def logical_or_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def logical_or_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] or viewB[tid]
 
 
 @pk.workunit
-def logical_or_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def logical_or_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
     out[tid] = viewA[tid] or viewB[tid]
 
 
@@ -1109,11 +1109,11 @@ def logical_or(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view (uint8)
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
+    out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
             viewA.shape[0],
@@ -1135,12 +1135,12 @@ def logical_or(viewA, viewB):
 
 
 @pk.workunit
-def logical_xor_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+def logical_xor_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
     out[tid] = bool(viewA[tid]) ^ bool(viewB[tid])
 
 
 @pk.workunit
-def logical_xor_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+def logical_xor_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
     out[tid] = bool(viewA[tid]) ^ bool(viewB[tid])
 
 
@@ -1157,11 +1157,11 @@ def logical_xor(viewA, viewB):
 
     Returns
     -------
-    out : pykokkos view (uint16)
+    out : pykokkos view (uint8)
            Output view.
 
     """
-    out = pk.View([viewA.shape[0]], pk.uint16)
+    out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
             viewA.shape[0],
@@ -1183,12 +1183,12 @@ def logical_xor(viewA, viewB):
 
 
 @pk.workunit
-def logical_not_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+def logical_not_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
     out[tid] = not view[tid]
 
 
 @pk.workunit
-def logical_not_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+def logical_not_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
     out[tid] = not view[tid]
 
 
@@ -1203,15 +1203,14 @@ def logical_not(view):
 
     Returns
     -------
-    out : pykokkos view
+    out : pykokkos view (uint8)
            Output view.
 
     """
+    out = pk.View([view.shape[0]], pk.uint8)
     if str(view.dtype) == "DataType.double":
-        out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], logical_not_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
-        out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], logical_not_impl_1d_float, view=view, out=out)
     return out
 

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -799,3 +799,537 @@ def logaddexp(viewA, viewB):
     else:
         raise RuntimeError("Incompatible Types")
     return out
+
+def true_divide(viewA, viewB):
+    """
+    true_divide is an alias of divide
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+
+    return divide(viewA, viewB)
+
+
+@pk.workunit
+def logaddexp2_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double],):
+    out[tid] = log2(pow(2, viewA[tid]) + pow(2, viewB[tid]))
+
+@pk.workunit
+def logaddexp2_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float],):
+    out[tid] = log2(pow(2, viewA[tid]) + pow(2, viewB[tid]))
+
+
+def logaddexp2(viewA, viewB):
+    """
+    Return a view with log(pow(2, a) + pow(2, b)) calculated for
+    positionally corresponding elements in viewA and viewB
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        out = pk.View([viewA.shape[0]], pk.double)
+        pk.parallel_for(
+            viewA.shape[0],
+            logaddexp2_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        out = pk.View([viewA.shape[0]], pk.float)
+        pk.parallel_for(
+            viewA.shape[0],
+            logaddexp2_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+
+@pk.workunit
+def floor_divide_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = viewA[tid] // viewB[tid]
+
+@pk.workunit
+def floor_divide_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = viewA[tid] // viewB[tid]
+
+
+def floor_divide(viewA, viewB):
+    """
+    Divides positionally corresponding elements
+    of viewA with elements of viewB and floors the result
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        out = pk.View([viewA.shape[0]], pk.double)
+        pk.parallel_for(
+            viewA.shape[0],
+            floor_divide_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        out = pk.View([viewA.shape[0]], pk.float)
+        pk.parallel_for(
+            viewA.shape[0],
+            floor_divide_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+
+@pk.workunit
+def sin_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = sin(view[tid])
+
+@pk.workunit
+def sin_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = sin(view[tid])
+
+def sin(view):
+    """
+    Element-wise trignometric sine of the view
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], sin_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], sin_impl_1d_float, view=view, out=out)
+    return out
+
+@pk.workunit
+def cos_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = cos(view[tid])
+
+@pk.workunit
+def cos_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = cos(view[tid])
+
+def cos(view):
+    """
+    Element-wise trignometric cosine of the view
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], cos_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], cos_impl_1d_float, view=view, out=out)
+    return out
+
+@pk.workunit
+def tan_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = tan(view[tid])
+
+@pk.workunit
+def tan_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = tan(view[tid])
+
+def tan(view):
+    """
+    Element-wise tangent of the view
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], tan_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], tan_impl_1d_float, view=view, out=out)
+    return out
+
+@pk.workunit
+def logical_and_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+    out[tid] = viewA[tid] and viewB[tid]
+
+@pk.workunit
+def logical_and_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+    out[tid] = viewA[tid] and viewB[tid]
+
+
+def logical_and(viewA, viewB):
+    """
+    Return the element-wise truth value of viewA AND viewB.
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view (uint16)
+           Output view.
+
+    """
+    out = pk.View([viewA.shape[0]], pk.uint16)
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_and_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_and_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+@pk.workunit
+def logical_or_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+    out[tid] = viewA[tid] or viewB[tid]
+
+@pk.workunit
+def logical_or_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+    out[tid] = viewA[tid] or viewB[tid]
+
+
+def logical_or(viewA, viewB):
+    """
+    Return the element-wise truth value of viewA OR viewB.
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view (uint16)
+           Output view.
+
+    """
+    out = pk.View([viewA.shape[0]], pk.uint16)
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_or_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_or_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+@pk.workunit
+def logical_xor_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+    out[tid] = bool(viewA[tid]) ^ bool(viewB[tid])
+
+@pk.workunit
+def logical_xor_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+    out[tid] = bool(viewA[tid]) ^ bool(viewB[tid])
+
+
+def logical_xor(viewA, viewB):
+    """
+    Return the element-wise truth value of viewA XOR viewB.
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view (uint16)
+           Output view.
+
+    """
+    out = pk.View([viewA.shape[0]], pk.uint16)
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_xor_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        pk.parallel_for(
+            viewA.shape[0],
+            logical_xor_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+@pk.workunit
+def logical_not_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = not view[tid]
+
+@pk.workunit
+def logical_not_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = not view[tid]
+
+def logical_not(view):
+    """
+    Element-wise logical_not of the view.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], logical_not_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], logical_not_impl_1d_float, view=view, out=out)
+    return out
+
+@pk.workunit
+def fmax_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+    out[tid] = fmax(viewA[tid], viewB[tid])
+
+@pk.workunit
+def fmax_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+    out[tid] = fmax(viewA[tid], viewB[tid])
+
+def fmax(viewA, viewB):
+    """
+    Return the element-wise fmax.
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view (uint16)
+           Output view.
+
+    """
+    out = pk.View([viewA.shape[0]], pk.uint16)
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        pk.parallel_for(
+            viewA.shape[0],
+            fmax_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        pk.parallel_for(
+            viewA.shape[0],
+            fmax_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+@pk.workunit
+def fmin_impl_1d_double(tid: int, viewA: pk.View1D[pk.double], viewB: pk.View1D[pk.double], out: pk.View1D[pk.uint16]):
+    out[tid] = fmin(viewA[tid], viewB[tid])
+
+@pk.workunit
+def fmin_impl_1d_float(tid: int, viewA: pk.View1D[pk.float], viewB: pk.View1D[pk.float], out: pk.View1D[pk.uint16]):
+    out[tid] = fmin(viewA[tid], viewB[tid])
+
+def fmin(viewA, viewB):
+    """
+    Return the element-wise fmin.
+
+    Parameters
+    ----------
+    viewA : pykokkos view
+            Input view.
+    viewB : pykokkos view
+            Input view.
+
+    Returns
+    -------
+    out : pykokkos view (uint16)
+           Output view.
+
+    """
+    out = pk.View([viewA.shape[0]], pk.uint16)
+    if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
+        pk.parallel_for(
+            viewA.shape[0],
+            fmin_impl_1d_double,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+
+    elif str(viewA.dtype) == "DataType.float" and str(viewB.dtype) == "DataType.float":
+        pk.parallel_for(
+            viewA.shape[0],
+            fmin_impl_1d_float,
+            viewA=viewA,
+            viewB=viewB,
+            out=out)
+    else:
+        raise RuntimeError("Incompatible Types")
+    return out
+
+@pk.workunit
+def exp_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = exp(view[tid])
+
+@pk.workunit
+def exp_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = exp(view[tid])
+
+def exp(view):
+    """
+    Element-wise exp of the view.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], exp_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], exp_impl_1d_float, view=view, out=out)
+    return out
+
+
+@pk.workunit
+def exp2_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.double]):
+    out[tid] = pow(2, view[tid])
+
+@pk.workunit
+def exp2_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.float]):
+    out[tid] = pow(2, view[tid])
+
+def exp2(view):
+    """
+    Element-wise 2**x of the view.
+
+    Parameters
+    ----------
+    view : pykokkos view
+           Input view.
+
+    Returns
+    -------
+    out : pykokkos view
+           Output view.
+
+    """
+    if str(view.dtype) == "DataType.double":
+        out = pk.View([view.shape[0]], pk.double)
+        pk.parallel_for(view.shape[0], exp2_impl_1d_double, view=view, out=out)
+    elif str(view.dtype) == "DataType.float":
+        out = pk.View([view.shape[0]], pk.float)
+        pk.parallel_for(view.shape[0], exp2_impl_1d_float, view=view, out=out)
+    return out

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -328,7 +328,7 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     actual = pk_ufunc(view=view)
     # log10 single-precision needs relaxed tol
     # for now
-    if numpy_ufunc in {np.log10, np.cos} and numpy_dtype == np.float32:
+    if numpy_ufunc in {np.log10, np.cos, np.tan} and numpy_dtype == np.float32:
         assert_allclose(actual, expected, rtol=1.5e-7)
     else:
         assert_allclose(actual, expected)

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -328,7 +328,7 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     actual = pk_ufunc(view=view)
     # log10 single-precision needs relaxed tol
     # for now
-    if numpy_ufunc in [np.log10, np.cos] and numpy_dtype == np.float32:
+    if numpy_ufunc in {np.log10, np.cos} and numpy_dtype == np.float32:
         assert_allclose(actual, expected, rtol=1.5e-7)
     else:
         assert_allclose(actual, expected)

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -304,6 +304,12 @@ def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
         (pk.negative, np.negative),
         (pk.positive, np.positive),
         (pk.square, np.square),
+        (pk.sin, np.sin),
+        (pk.cos, np.cos),
+        (pk.tan, np.tan),
+        (pk.logical_not, np.logical_not),
+        (pk.exp, np.exp),
+        (pk.exp2, np.exp2),
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
@@ -322,7 +328,7 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     actual = pk_ufunc(view=view)
     # log10 single-precision needs relaxed tol
     # for now
-    if numpy_ufunc == np.log10 and numpy_dtype == np.float32:
+    if numpy_ufunc in [np.log10, np.cos] and numpy_dtype == np.float32:
         assert_allclose(actual, expected, rtol=1.5e-7)
     else:
         assert_allclose(actual, expected)
@@ -337,6 +343,15 @@ def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
         (pk.fmod, np.fmod),
         (pk.greater, np.greater),
         (pk.logaddexp, np.logaddexp),
+        (pk.floor_divide, np.floor_divide),
+        (pk.true_divide, np.true_divide),
+        (pk.logaddexp2, np.logaddexp2),
+        (pk.logical_and, np.logical_and),
+        (pk.logical_or, np.logical_or),
+        (pk.logical_xor, np.logical_xor),
+        (pk.fmax, np.fmax),
+        (pk.fmin, np.fmin),
+
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),


### PR DESCRIPTION
The ufuncs this PR covers include:

- true_divide
- logaddexp2
- floor_divide
- sin
- cos
- tan
- logical_and
- logical_or
- logical_xor
- logical_not
- fmax
- fmin
- exp
- exp2

As of now these ufuncs only supports 1D (float and double) Views as input .