### PR TITLE
ENH: add API constants

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11.0-rc.1"]
+        python-version: ["3.8", "3.9", "3.10.6", "3.11.0-rc.1"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -44,10 +44,13 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  fmax,
                                  fmin,
                                  exp,
-                                 exp2)
+                                 exp2,
+                                isinf,
+                                isnan)
 from pykokkos.lib.info import iinfo, finfo
 from pykokkos.lib.create import zeros
 from pykokkos.lib.util import all, any
+from pykokkos.lib.constants import e, pi, inf, nan
 
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -532,7 +532,7 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
     # TODO: proper implementation/design
     # for now, let's cheat and use NumPy asarray() followed
     # by pykokkos from_numpy()
-    if obj in [pk.e, pk.pi, pk.inf, pk.nan]:
+    if obj in {pk.e, pk.pi, pk.inf, pk.nan}:
         view = pk.View([1], dtype=pk.float32)
         view[:] = obj
         return view

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -532,6 +532,10 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
     # TODO: proper implementation/design
     # for now, let's cheat and use NumPy asarray() followed
     # by pykokkos from_numpy()
+    if obj in [pk.e, pk.pi, pk.inf, pk.nan]:
+        view = pk.View([1], dtype=pk.float32)
+        view[:] = obj
+        return view
     if "bool" in str(dtype):
         dtype = np.bool_
     arr = np.asarray(obj, dtype=dtype)

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -533,7 +533,9 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
     # for now, let's cheat and use NumPy asarray() followed
     # by pykokkos from_numpy()
     if obj in {pk.e, pk.pi, pk.inf, pk.nan}:
-        view = pk.View([1], dtype=pk.float32)
+        if dtype is None:
+            dtype = pk.float64
+        view = pk.View([1], dtype=dtype)
         view[:] = obj
         return view
     if "bool" in str(dtype):

--- a/pykokkos/lib/constants.py
+++ b/pykokkos/lib/constants.py
@@ -1,0 +1,6 @@
+import math
+
+e = math.e
+pi = math.pi
+inf = math.inf
+nan = math.nan

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1379,3 +1379,53 @@ def exp2(view):
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], exp2_impl_1d_float, view=view, out=out)
     return out
+
+
+@pk.workunit
+def isnan_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
+    out[tid] = isnan(view[tid])
+
+
+@pk.workunit
+def isnan_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
+    out[tid] = isnan(view[tid])
+
+
+def isnan(view):
+    out = pk.View([*view.shape], dtype=pk.uint8)
+    if "double" in str(view.dtype) or "float64" in str(view.dtype):
+        pk.parallel_for(view.shape[0],
+                        isnan_impl_1d_double,
+                        view=view,
+                        out=out)
+    elif "float" in str(view.dtype):
+        pk.parallel_for(view.shape[0],
+                        isnan_impl_1d_float,
+                        view=view,
+                        out=out)
+    return out
+
+
+@pk.workunit
+def isinf_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+def isinf(view):
+    out = pk.View([*view.shape], dtype=pk.uint8)
+    if "double" in str(view.dtype) or "float64" in str(view.dtype):
+        pk.parallel_for(view.shape[0],
+                        isinf_impl_1d_double,
+                        view=view,
+                        out=out)
+    elif "float" in str(view.dtype):
+        pk.parallel_for(view.shape[0],
+                        isinf_impl_1d_float,
+                        view=view,
+                        out=out)
+    return out

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,6 @@ setup(
     name="pykokkos",
     version="0.1",
     packages=find_packages(include=["pykokkos", "pykokkos.*"]),
-    include_package_data=True
+    include_package_data=True,
+    package_data={"": ["*.sh"]}
 )


### PR DESCRIPTION
* Fixes #68 by adding the `pk.e`, `pk.pi`, `pk.inf`, and `pk.nan` constants needed to pass `array_api_tests/test_constants.py` (we'll see if the CI agrees with me...)

* the implementations are a bit crude, but do seem to pass tests locally at least

* note that some of the infrastructure here is borrowed from other unmerged PRs