### PR TITLE
Enable usage of multiple CUDA GPUs in PyKokkos

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py

--- a/examples/pykokkos/multi_gpu.py
+++ b/examples/pykokkos/multi_gpu.py
@@ -1,0 +1,60 @@
+import pykokkos as pk
+
+import numpy as np
+import cupy as cp
+
+pk.set_default_space(pk.Cuda)
+
+size = 10000
+
+pk.set_device_id(0)
+cp_arr_0 = cp.arange(size).astype(np.int32)
+
+pk.set_device_id(1)
+cp_arr_1 = cp.arange(size).astype(np.int32)
+
+print(cp_arr_0.device)
+print(cp_arr_1.device)
+
+@pk.workunit(cp_arr = pk.ViewTypeInfo(space=pk.CudaSpace))
+def reduction_cp(i: int, acc: pk.Acc[int], cp_arr: pk.View1D[int]):
+    acc += cp_arr[i]
+
+pk.set_device_id(1)
+cp_view_0 = pk.from_cupy(cp_arr_1)
+result_0 = pk.parallel_reduce(pk.RangePolicy(pk.Cuda, 0, size), reduction_cp, cp_arr=cp_view_0)
+print(result_0)
+
+pk.set_device_id(0)
+cp_view_1 = pk.from_cupy(cp_arr_0)
+result_1 = pk.parallel_reduce(pk.RangePolicy(pk.Cuda, 0, size), reduction_cp, cp_arr=cp_view_1)
+
+print(f"Reducing array 0: {result_0}")
+print(f"Reducing array 1: {result_1}")
+print(f"Sum: {result_0 + result_1}")
+
+pk.set_device_id(0)
+view_0 = pk.View((size,), dtype=int)
+
+pk.set_device_id(1)
+view_1 = pk.View((size,), dtype=int)
+
+@pk.workunit
+def init_view(i: int, view: pk.View1D[int]):
+    view[i] = i
+
+@pk.workunit
+def reduce_view(i: int, acc: pk.Acc[int], view: pk.View1D[int]):
+    acc += view[i]
+
+pk.set_device_id(0)
+pk.parallel_for(pk.RangePolicy(pk.Cuda, 0, size), init_view, view=view_0)
+result_0 = pk.parallel_reduce(pk.RangePolicy(pk.Cuda, 0, size), reduce_view, view=view_0)
+
+pk.set_device_id(1)
+pk.parallel_for(pk.RangePolicy(pk.Cuda, 0, size), init_view, view=view_1)
+result_1 = pk.parallel_reduce(pk.RangePolicy(pk.Cuda, 0, size), reduce_view, view=view_1)
+
+print(f"Reducing view 0: {result_0}")
+print(f"Reducing view 1: {result_1}")
+print(f"Sum: {result_0 + result_1}")

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -47,9 +47,14 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  exp2,
                                 isinf,
                                 isnan,
-                                equal)
+                                equal,
+                             isfinite)
 from pykokkos.lib.info import iinfo, finfo
-from pykokkos.lib.create import zeros, ones
+from pykokkos.lib.create import (zeros,
+                                 ones,
+                                 ones_like,
+                                 full)
+from pykokkos.lib.manipulate import reshape
 from pykokkos.lib.util import all, any
 from pykokkos.lib.constants import e, pi, inf, nan
 

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -8,7 +8,8 @@ from pykokkos.kokkos_manager import (
     initialize, finalize,
     get_default_space, set_default_space,
     get_default_precision, set_default_precision,
-    is_uvm_enabled, enable_uvm, disable_uvm
+    is_uvm_enabled, enable_uvm, disable_uvm,
+    set_device_id
 )
 
 initialize()

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -46,9 +46,10 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  exp,
                                  exp2,
                                 isinf,
-                                isnan)
+                                isnan,
+                                equal)
 from pykokkos.lib.info import iinfo, finfo
-from pykokkos.lib.create import zeros
+from pykokkos.lib.create import zeros, ones
 from pykokkos.lib.util import all, any
 from pykokkos.lib.constants import e, pi, inf, nan
 

--- a/pykokkos/core/compile.sh
+++ b/pykokkos/core/compile.sh
@@ -9,6 +9,7 @@ PK_REAL="${6}"
 KOKKOS_LIB_PATH="${7}"
 KOKKOS_INCLUDE_PATH="${8}"
 COMPUTE_CAPABILITY="${9}"
+LIB_SUFFIX="${10}"
 SRC=$(find -name "*.cpp")
 
 
@@ -34,11 +35,11 @@ if [ "${COMPILER}" == "g++" ]; then
         -shared \
         -fopenmp \
         "${SRC}".o -o "${MODULE}" \
-        "${KOKKOS_LIB_PATH}/libkokkoscontainers.so" \
-        "${KOKKOS_LIB_PATH}/libkokkoscore.so"
+        "${KOKKOS_LIB_PATH}/libkokkoscontainers${LIB_SUFFIX}.so" \
+        "${KOKKOS_LIB_PATH}/libkokkoscore${LIB_SUFFIX}.so"
 
 elif [ "${COMPILER}" == "nvcc" ]; then
-        "${KOKKOS_LIB_PATH}/../bin/nvcc_wrapper" \
+        "${KOKKOS_LIB_PATH}/../../bin/nvcc_wrapper" \
         `python3 -m pybind11 --includes` \
         -I.. \
         -O3 \
@@ -54,7 +55,7 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         -Dpk_exec_space="Kokkos::${EXEC_SPACE}" \
         -Dpk_real="${PK_REAL}"
 
-        "${KOKKOS_LIB_PATH}/../bin/nvcc_wrapper" \
+        "${KOKKOS_LIB_PATH}/../../bin/nvcc_wrapper" \
         -I.. \
         -O3 \
         -shared \
@@ -62,6 +63,6 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         --expt-extended-lambda \
         -fopenmp \
         "${SRC}".o -o "${MODULE}" \
-        "${KOKKOS_LIB_PATH}/libkokkoscontainers.so" \
-        "${KOKKOS_LIB_PATH}/libkokkoscore.so"
+        "${KOKKOS_LIB_PATH}/libkokkoscontainers${LIB_SUFFIX}.so" \
+        "${KOKKOS_LIB_PATH}/libkokkoscore${LIB_SUFFIX}.so"
 fi

--- a/pykokkos/core/compile.sh
+++ b/pykokkos/core/compile.sh
@@ -56,7 +56,11 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         -Dpk_exec_space="Kokkos::${EXEC_SPACE}" \
         -Dpk_real="${PK_REAL}"
 
+<<<<<<< HEAD
         "${COMPILER_PATH}" \
+=======
+        "${KOKKOS_LIB_PATH}/../../bin/nvcc_wrapper" \
+>>>>>>> 399d9cb45296bbfa2f1f88a3c71e1f45799e7d26
         -I.. \
         -O3 \
         -shared \

--- a/pykokkos/core/compile.sh
+++ b/pykokkos/core/compile.sh
@@ -10,6 +10,7 @@ KOKKOS_LIB_PATH="${7}"
 KOKKOS_INCLUDE_PATH="${8}"
 COMPUTE_CAPABILITY="${9}"
 LIB_SUFFIX="${10}"
+COMPILER_PATH="${11}"
 SRC=$(find -name "*.cpp")
 
 
@@ -39,7 +40,7 @@ if [ "${COMPILER}" == "g++" ]; then
         "${KOKKOS_LIB_PATH}/libkokkoscore${LIB_SUFFIX}.so"
 
 elif [ "${COMPILER}" == "nvcc" ]; then
-        "${KOKKOS_LIB_PATH}/../../bin/nvcc_wrapper" \
+        "${COMPILER_PATH}" \
         `python3 -m pybind11 --includes` \
         -I.. \
         -O3 \
@@ -55,7 +56,7 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         -Dpk_exec_space="Kokkos::${EXEC_SPACE}" \
         -Dpk_real="${PK_REAL}"
 
-        "${KOKKOS_LIB_PATH}/../../bin/nvcc_wrapper" \
+        "${COMPILER_PATH}" \
         -I.. \
         -O3 \
         -shared \

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -178,7 +178,7 @@ class Compiler:
         if module_setup.is_compiled():
             return
 
-        cpp_setup = CppSetup(module_setup.module_file, self.functor_file, self.bindings_file)
+        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files, self.functor_file, self.bindings_file)
         translator = StaticTranslator(module_setup.name, self.functor_file, members)
 
         t_start: float = time.perf_counter()

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -189,6 +189,20 @@ class CppSetup:
 
         return f"_{km.get_device_id()}"
 
+    def get_kokkos_lib_suffix(self, space: ExecutionSpace) -> str:
+        """
+        Get the suffix of the libkokkoscore and libkokkoscontainers
+        libraries corresponding to the enabled device
+
+        :param space: the execution space to compile for
+        :returns: the suffix as a string
+        """
+
+        if is_host_execution_space(space) or not km.is_multi_gpu_enabled():
+            return ""
+
+        return f"_{km.get_device_id()}"
+
     def invoke_script(self, output_dir: Path, space: ExecutionSpace, enable_uvm: bool, compiler: str) -> None:
         """
         Invoke the compilation script

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -3,10 +3,13 @@ from pathlib import Path
 import shutil
 import subprocess
 import sys
+from types import ModuleType
 from typing import List, Tuple
 
-
-from pykokkos.interface import ExecutionSpace, get_default_layout, get_default_memory_space
+from pykokkos.interface import (
+    ExecutionSpace, get_default_layout, get_default_memory_space,
+    is_host_execution_space
+)
 import pykokkos.kokkos_manager as km
 
 
@@ -15,16 +18,18 @@ class CppSetup:
     Creates the directory to hold the translation and invokes the compiler
     """
 
-    def __init__(self, module_file: str, functor: str, bindings: str):
+    def __init__(self, module_file: str, gpu_module_files: List[str], functor: str, bindings: str):
         """
         CppSetup constructor
 
         :param module: the name of the file containing the compiled Python module
+        :param gpu_module_files: the list of names of files containing for each gpu module
         :param functor: the name of the generated functor file
         :param bindings: the name of the generated bindings file
         """
 
         self.module_file: str = module_file
+        self.gpu_module_files: List[str] = gpu_module_files
         self.functor_file: str = functor
         self.bindings_file: str = bindings
 
@@ -58,6 +63,8 @@ class CppSetup:
         self.write_source(output_dir, functor, bindings)
         self.copy_script(output_dir)
         self.invoke_script(output_dir, space, enable_uvm, compiler)
+        if space is ExecutionSpace.Cuda and km.is_multi_gpu_enabled():
+            self.copy_multi_gpu_kernel(output_dir)
 
 
     def initialize_directory(self, name: Path) -> None:
@@ -115,13 +122,14 @@ class CppSetup:
             print(f"Exception while copying views and makefile: {ex}")
             sys.exit(1)
 
-    def get_kokkos_paths(self) -> Tuple[Path, Path]:
+    def get_kokkos_paths(self, space: ExecutionSpace) -> Tuple[Path, Path]:
         """
         Get the paths of the Kokkos instal lib and include
         directories. If the environment variable is set, use that
-        Kokkos install. If not, fall back to installed pykokkos-base
-        package.
+        Kokkos install. If not, fall back to the installed
+        pykokkos-base package.
 
+        :param space: the execution space to compile for
         :returns: a tuple of paths to the Kokkos lib/ and include/
             directories respectively
         """
@@ -139,8 +147,9 @@ class CppSetup:
 
             return lib_path, include_path
 
-        from pykokkos.bindings import kokkos
-        install_path = Path(kokkos.__path__[0]).parent
+        is_cpu: bool = is_host_execution_space(space)
+        kokkos_lib: ModuleType = km.get_kokkos_module(is_cpu)
+        install_path = Path(kokkos_lib.__path__[0])
 
         if (install_path / "lib").is_dir():
             lib_path = install_path / "lib"
@@ -150,9 +159,23 @@ class CppSetup:
             raise RuntimeError("lib/ or lib64/ directories not found in installed pykokkos-base package."
                                f" Try setting {self.lib_path_env} instead.")
 
-        include_path = lib_path.parent / "include/kokkos"
+        include_path = lib_path.parent.parent / "include/kokkos"
 
         return lib_path, include_path
+
+    def get_kokkos_lib_suffix(self, space: ExecutionSpace) -> str:
+        """
+        Get the suffix of the libkokkoscore and libkokkoscontainers
+        libraries corresponding to the enabled device
+
+        :param space: the execution space to compile for
+        :returns: the suffix as a string
+        """
+
+        if is_host_execution_space(space) or not km.is_multi_gpu_enabled():
+            return ""
+
+        return f"_{km.get_device_id()}"
 
     def invoke_script(self, output_dir: Path, space: ExecutionSpace, enable_uvm: bool, compiler: str) -> None:
         """
@@ -176,8 +199,9 @@ class CppSetup:
         precision: str = km.get_default_precision().__name__.split(".")[-1]
         lib_path: Path
         include_path: Path
-        lib_path, include_path = self.get_kokkos_paths()
+        lib_path, include_path = self.get_kokkos_paths(space)
         compute_capability: str = self.get_cuda_compute_capability(compiler)
+        lib_suffix: str = self.get_kokkos_lib_suffix(space)
 
         command: List[str] = [f"./{self.script}",
                               compiler,             # What compiler to use
@@ -188,7 +212,8 @@ class CppSetup:
                               precision,            # Default real precision
                               str(lib_path),        # Path to Kokkos install lib/ directory
                               str(include_path),    # Path to Kokkos install include/ directory
-                              compute_capability]   # Device compute capability
+                              compute_capability,   # Device compute capability
+                              lib_suffix]           # The libkokkos* suffix identifying the gpu
         compile_result = subprocess.run(command, cwd=output_dir, capture_output=True, check=False)
 
         if compile_result.returncode != 0:
@@ -206,6 +231,49 @@ class CppSetup:
             print(patchelf_result.stderr.decode("utf-8"))
             print(f"patchelf failed")
             sys.exit(1)
+
+    def copy_multi_gpu_kernel(self, output_dir: Path) -> None:
+        """
+        Copy the kernel .so file once for each device and run patchelf
+        to point to the right library
+
+        :param output_dir: the base directory
+        """
+
+        original_module: Path = output_dir / self.module_file
+        for id, (kernel_filename, kokkos_gpu_module) in enumerate(zip(self.gpu_module_files, km.get_kokkos_gpu_modules())):
+            kernel_path: Path = output_dir / kernel_filename
+
+            try:
+                shutil.copy(original_module, kernel_path)
+            except Exception as ex:
+                print(f"Exception while copying kernel: {ex}")
+                sys.exit(1)
+
+            lib_path: Path = Path(kokkos_gpu_module.__path__[0]) / "lib"
+            patchelf: List[str] = ["patchelf",
+                                "--set-rpath",
+                                str(lib_path),
+                                kernel_filename]
+
+            patchelf_result = subprocess.run(patchelf, cwd=output_dir, capture_output=True, check=False)
+            if patchelf_result.returncode != 0:
+                print(patchelf_result.stderr.decode("utf-8"))
+                print(f"patchelf failed")
+                sys.exit(1)
+
+            # Now replace the needed libkokkos* libraries with the correct version
+            needed_libraries: str = subprocess.run(["patchelf", "--print-needed", kernel_filename], cwd=output_dir, capture_output=True, check=False).stdout.decode("utf-8")
+
+            for line in needed_libraries.splitlines():
+                if "libkokkoscore" in line or "libkokkoscontainers" in line:
+                    # Line will be of the form f"libkokkoscore_{id}.so.3.4"
+                    # This will extract id
+                    current_id: int = int(line.split("_")[1].split(".")[0])
+                    to_remove: str = line
+                    to_add: str = line.replace(f"_{current_id}", f"_{id}")
+
+                    subprocess.run(["patchelf", "--replace-needed", to_remove, to_add, kernel_filename], cwd=output_dir, capture_output=True, check=False)
 
     def get_cuda_compute_capability(self, compiler: str) -> str:
         """

--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 import sysconfig
 import time
-from typing import Callable, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from pykokkos.interface import ExecutionSpace
 import pykokkos.kokkos_manager as km
@@ -105,9 +105,15 @@ class ModuleSetup:
 
         self.main: Path = self.get_main_path()
         self.output_dir: Optional[Path] = self.get_output_dir(self.main, self.metadata, space)
+        self.gpu_module_files: List[str] = []
+        if km.is_multi_gpu_enabled():
+            self.gpu_module_files = [f"kernel{device_id}{suffix}" for device_id in range(km.get_num_gpus())]
 
         if self.output_dir is not None:
             self.path: str = os.path.join(self.output_dir, self.module_file)
+            if km.is_multi_gpu_enabled():
+                self.gpu_module_paths: str = [os.path.join(self.output_dir, module_file) for module_file in self.gpu_module_files]
+
             self.name: str = self.path.replace("/", "_")
             self.name: str = self.name.replace("-", "_")
             self.name: str = self.name.replace(".", "_")

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -120,7 +120,7 @@ class Runtime:
         """
 
         module_path: str
-        if is_host_execution_space(space):
+        if is_host_execution_space(space) or not km.is_multi_gpu_enabled():
             module_path = module_setup.path
         else:
             device_id: int = km.get_device_id()

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -269,7 +269,7 @@ def generate_call(operation: str, functor: str, members: PyKokkosMembers, tag: c
     if is_hierarchical:
         args.append(f"Kokkos::TeamPolicy<{Keywords.DefaultExecSpace.value},{functor}::{tag_name}>({Keywords.LeagueSize.value},Kokkos::AUTO,{Keywords.VectorLength.value})")
     else:
-        args.append(f"Kokkos::RangePolicy<{Keywords.DefaultExecSpace.value},{functor}::{tag_name}>({Keywords.ThreadsBegin.value},{Keywords.ThreadsEnd.value})")
+        args.append(f"Kokkos::RangePolicy<{Keywords.DefaultExecSpace.value},{functor}::{tag_name}>({Keywords.DefaultExecSpaceInstance.value}, {Keywords.ThreadsBegin.value},{Keywords.ThreadsEnd.value})")
 
     args.append(Keywords.Instance.value)
 

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -27,7 +27,7 @@ from .execution_policy import (
     ExecutionPolicy, RangePolicy, MDRangePolicy, TeamPolicy,
     TeamThreadRange, ThreadVectorRange, Iterate, Rank
 )
-from .execution_space import ExecutionSpace
+from .execution_space import ExecutionSpace, is_host_execution_space
 from .layout import Layout, get_default_layout
 from .hierarchical import (
     AUTO, TeamMember, PerTeam, PerThread, single

--- a/pykokkos/interface/data_types.py
+++ b/pykokkos/interface/data_types.py
@@ -34,46 +34,60 @@ class DataTypeClass:
 
 class uint8(DataTypeClass):
     value = kokkos.uint8
+    np_equiv = np.uint8
 
 class int8(DataTypeClass):
     value = kokkos.int8
+    np_equiv = np.int8
 
 class int16(DataTypeClass):
     value = kokkos.int16
+    np_equiv = np.int16
 
 class int32(DataTypeClass):
     value = kokkos.int32
+    np_equiv = np.int32
 
 class int64(DataTypeClass):
     value = kokkos.int64
+    np_equiv = np.int64
 
 class uint16(DataTypeClass):
     value = kokkos.uint16
+    np_equiv = np.uint16
 
 
 class uint32(DataTypeClass):
     value = kokkos.int32
+    np_equiv = np.uint32
 
 
 class uint64(DataTypeClass):
     value = kokkos.int64
+    np_equiv = np.uint64
 
 
 class float(DataTypeClass):
     value = kokkos.float
+    np_equiv = np.float32
 
 class double(DataTypeClass):
     value = kokkos.double
+    np_equiv = np.float64
 
 
 class real(DataTypeClass):
     value = None
+    np_equiv = None
 
 class float32(DataTypeClass):
     value = kokkos.float
+    np_equiv = np.float32
 
 class float64(DataTypeClass):
     value = kokkos.double
+    np_equiv = np.float64
 
 class bool(DataTypeClass):
-    value = kokkos.int16
+    value = kokkos.uint8
+    np_equiv = np.bool_

--- a/pykokkos/interface/data_types.py
+++ b/pykokkos/interface/data_types.py
@@ -58,12 +58,12 @@ class uint16(DataTypeClass):
 
 
 class uint32(DataTypeClass):
-    value = kokkos.int32
+    value = kokkos.uint32
     np_equiv = np.uint32
 
 
 class uint64(DataTypeClass):
-    value = kokkos.int64
+    value = kokkos.uint64
     np_equiv = np.uint64
 
 

--- a/pykokkos/interface/execution_space.py
+++ b/pykokkos/interface/execution_space.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+import pykokkos.kokkos_manager as km
 
 class ExecutionSpace(Enum):
     Cuda = "Cuda"
@@ -8,3 +9,16 @@ class ExecutionSpace(Enum):
     Serial = "Serial"
     Debug = "Debug"
     Default = "Default"
+
+def is_host_execution_space(space: ExecutionSpace) -> bool:
+    """
+    Check if the supplied execution space runs on the host
+
+    :param space: the space being checked
+    :returns: True if the space runs on the host
+    """
+
+    if space is ExecutionSpace.Default:
+        space = km.get_default_space()
+
+    return space in {ExecutionSpace.OpenMP, ExecutionSpace.Pthreads, ExecutionSpace.Serial}

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -280,14 +280,6 @@ class View(ViewType):
             self.dtype = DataType.float
         elif self.dtype == pk.double:
             self.dtype = DataType.double
-        elif self.dtype == pk.int32:
-            self.dtype = DataType.int32
-        elif self.dtype == pk.int64:
-            pass
-        elif self.dtype == pk.uint32:
-            self.dtype = DataType.uint32
-        elif self.dtype == pk.uint64:
-            self.dtype = DataType.uint64
         if trait is trait.Unmanaged:
             if array is not None and array.ndim == 0:
                 # TODO: we don't really support 0-D under the hood--use

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -284,6 +284,10 @@ class View(ViewType):
             self.dtype = DataType.int32
         elif self.dtype == pk.int64:
             pass
+        elif self.dtype == pk.uint32:
+            self.dtype = DataType.uint32
+        elif self.dtype == pk.uint64:
+            self.dtype = DataType.uint64
         if trait is trait.Unmanaged:
             self.array = kokkos.unmanaged_array(array, dtype=self.dtype.value, space=self.space.value, layout=self.layout.value)
         else:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -22,7 +22,7 @@ from .data_types import (
     int16, int32, int64,
     uint8,
     uint16, uint32, uint64,
-    double
+    double, float64,
 )
 from .layout import get_default_layout, Layout
 from .memory_space import get_default_memory_space, MemorySpace
@@ -138,8 +138,14 @@ class ViewType:
         :returns: the length of the first dimension
         """
 
+        # NOTE: careful with 0-D treatments and __bool__
+        # related handling; you can have shape () and
+        # still be True for example...
         if len(self.shape) == 0:
-            return 0
+            if self.data != 0:
+                return 1
+            else:
+                return 0
         return self.shape[0]
 
     def __iter__(self) -> Iterator:
@@ -149,7 +155,11 @@ class ViewType:
         :returns: an iterator over the data
         """
 
-        return (n for n in self.data)
+        if self.data.ndim > 0:
+            return (n for n in self.data)
+        else:
+            # 0-D case returns empty generator
+            return zip()
 
     def __str__(self) -> str:
         """
@@ -171,7 +181,7 @@ class ViewType:
 class View(ViewType):
     def __init__(
         self,
-        shape: List[int],
+        shape: Union[List[int], Tuple[int]],
         dtype: Union[DataTypeClass, type] = real,
         space: MemorySpace = MemorySpace.MemorySpaceDefault,
         layout: Layout = Layout.LayoutDefault,
@@ -181,7 +191,7 @@ class View(ViewType):
         """
         View constructor.
 
-        :param shape: the shape of the view as a list of integers
+        :param shape: the shape of the view as a list or tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -246,7 +256,7 @@ class View(ViewType):
         """
         Initialize the view
 
-        :param shape: the shape of the view as a list of integers
+        :param shape: the shape of the view as a list or tuple of integers
         :param dtype: the data type of the view, either a pykokkos DataType or "int" or "float".
         :param space: the memory space of the view. Will be set to the execution space of the view by default.
         :param layout: the layout of the view in memory.
@@ -255,8 +265,6 @@ class View(ViewType):
         """
 
         self.shape: Tuple[int] = tuple(shape)
-        if self.shape == (0,):
-            self.shape = ()
         self.size: int = math.prod(shape)
         self.dtype: Optional[DataType] = self._get_type(dtype)
         if self.dtype is None:
@@ -332,7 +340,10 @@ class View(ViewType):
 
 
     def __hash__(self):
-        hash_value = hash(self.array)
+        try:
+            hash_value = hash(self.array)
+        except TypeError:
+            hash_value = hash(self.array.data.tobytes())
         return hash_value
 
 
@@ -460,9 +471,9 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     elif np_dtype is np.float32:
         dtype = DataType.float # PyKokkos float
     elif np_dtype is np.float64:
-        dtype = double
+        dtype = float64
     elif np_dtype is np.bool_:
-        dtype = int16
+        dtype = uint8
     else:
         raise RuntimeError(f"ERROR: unsupported numpy datatype {np_dtype}")
 
@@ -482,7 +493,13 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     # temporary/terrible hack here for array API testing..
     if array.ndim == 0:
         ret_list = ()
-        array = np.array(array, dtype=np_dtype)
+        if np_dtype == np.bool_:
+            if array == 1:
+                array = np.array(1, dtype=np.uint8)
+            else:
+                array = np.array(0, dtype=np.uint8)
+        else:
+            array = np.array(array, dtype=np_dtype)
     else:
         ret_list = list((array.shape))
 
@@ -552,8 +569,6 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
         view = pk.View([1], dtype=dtype)
         view[:] = obj
         return view
-    if "bool" in str(dtype):
-        dtype = np.bool_
     if dtype is not None:
         arr = np.asarray(obj, dtype=dtype.np_equiv)
     else:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 import ctypes
-import os
 import math
 from enum import Enum
 import sys
+from types import ModuleType
 from typing import (
     Dict, Generic, Iterator, List, Optional,
     Tuple, TypeVar, Union
@@ -225,7 +225,10 @@ class View(ViewType):
             shape_list[dimension] = size
 
         self.shape = tuple(shape_list)
-        self.array = kokkos.array(
+
+        is_cpu: bool = self.space is MemorySpace.HostSpace
+        kokkos_lib: ModuleType = km.get_kokkos_module(is_cpu)
+        self.array = kokkos_lib.array(
             "", self.shape, None, None, self.dtype.value, self.space.value, self.layout.value, self.trait.value)
         self.data = np.array(self.array, copy=False)
 
@@ -284,6 +287,9 @@ class View(ViewType):
         self.layout: Layout = layout
         self.trait: Trait = trait
 
+        is_cpu: bool = self.space is MemorySpace.HostSpace
+        kokkos_lib: ModuleType = km.get_kokkos_module(is_cpu)
+
         if self.dtype == pk.float:
             self.dtype = DataType.float
         elif self.dtype == pk.double:
@@ -294,11 +300,11 @@ class View(ViewType):
                 # NumPy for now...
                 self.array = array
             else:
-                self.array = kokkos.unmanaged_array(array, dtype=self.dtype.value, space=self.space.value, layout=self.layout.value)
+                self.array = kokkos_lib.unmanaged_array(array, dtype=self.dtype.value, space=self.space.value, layout=self.layout.value)
         else:
             if len(self.shape) == 0:
                 shape = [1]
-            self.array = kokkos.array("", shape, None, None, self.dtype.value, space.value, layout.value, trait.value)
+            self.array = kokkos_lib.array("", shape, None, None, self.dtype.value, space.value, layout.value, trait.value)
         self.data = np.array(self.array, copy=False)
 
     def _get_type(self, dtype: Union[DataType, type]) -> Optional[DataType]:
@@ -382,10 +388,15 @@ class Subview(ViewType):
 
         self.data: np.ndarray = parent_view.data[data_slice]
         self.dtype = parent_view.dtype
-        self.array = kokkos.array(
+
+        is_cpu: bool = self.parent_view.space is MemorySpace.HostSpace
+        kokkos_lib: ModuleType = km.get_kokkos_module(is_cpu)
+
+        self.array = kokkos_lib.array(
             self.data, dtype=parent_view.dtype.value, space=parent_view.space.value,
             layout=parent_view.layout.value, trait=kokkos.Unmanaged)
         self.shape: Tuple[int] = self.data.shape
+
         if self.data.shape == (0,):
             self.data = np.array([], dtype=self.data.dtype)
             self.shape = ()

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -289,7 +289,12 @@ class View(ViewType):
         elif self.dtype == pk.uint64:
             self.dtype = DataType.uint64
         if trait is trait.Unmanaged:
-            self.array = kokkos.unmanaged_array(array, dtype=self.dtype.value, space=self.space.value, layout=self.layout.value)
+            if array is not None and array.ndim == 0:
+                # TODO: we don't really support 0-D under the hood--use
+                # NumPy for now...
+                self.array = array
+            else:
+                self.array = kokkos.unmanaged_array(array, dtype=self.dtype.value, space=self.space.value, layout=self.layout.value)
         else:
             if len(self.shape) == 0:
                 shape = [1]
@@ -325,6 +330,19 @@ class View(ViewType):
             return DataType["double"]
 
         return None
+
+
+    def __eq__(self, other):
+        if self.array == other:
+            return True
+        else:
+            return False
+
+
+    def __hash__(self):
+        hash_value = hash(self.array)
+        return hash_value
+
 
     @staticmethod
     def _get_dtype_name(type_name: str) -> str:
@@ -433,7 +451,7 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
 
     if np_dtype is np.int8:
         dtype = int8
-    if np_dtype is np.int16:
+    elif np_dtype is np.int16:
         dtype = int16
     elif np_dtype is np.int32:
         dtype = int32
@@ -472,7 +490,7 @@ def from_numpy(array: np.ndarray, space: Optional[MemorySpace] = None, layout: O
     # temporary/terrible hack here for array API testing..
     if array.ndim == 0:
         ret_list = ()
-        array = np.array(())
+        array = np.array(array, dtype=np_dtype)
     else:
         ret_list = list((array.shape))
 
@@ -544,7 +562,10 @@ def asarray(obj, /, *, dtype=None, device=None, copy=None):
         return view
     if "bool" in str(dtype):
         dtype = np.bool_
-    arr = np.asarray(obj, dtype=dtype)
+    if dtype is not None:
+        arr = np.asarray(obj, dtype=dtype.np_equiv)
+    else:
+        arr = np.asarray(obj)
     ret = from_numpy(arr)
     return ret
 

--- a/pykokkos/kokkos_manager/__init__.py
+++ b/pykokkos/kokkos_manager/__init__.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Dict
+from types import ModuleType
+from typing import Any, Dict, List
 
 from pykokkos.bindings import kokkos
 from pykokkos.interface.execution_space import ExecutionSpace
@@ -9,7 +10,12 @@ CONSTANTS: Dict[str, Any] = {
     "EXECUTION_SPACE": ExecutionSpace.OpenMP,
     "REAL_DTYPE": double,
     "IS_INITIALIZED": False,
-    "ENABLE_UVM": False
+    "ENABLE_UVM": False,
+    "MULTI_GPU": False,
+    "NUM_GPUS": 0,
+    "KOKKOS_GPU_MODULE": kokkos,
+    "KOKKOS_GPU_MODULE_LIST": [],
+    "DEVICE_ID": 0
 }
 
 def get_default_space() -> ExecutionSpace:
@@ -99,3 +105,110 @@ def finalize() -> None:
     if CONSTANTS["IS_INITIALIZED"] == True:
         kokkos.finalize()
         CONSTANTS["IS_INITIALIZED"] = False
+
+def get_kokkos_module(is_cpu: bool) -> ModuleType:
+    """
+    Get the current kokkos module
+
+    :param is_cpu: is the lib needed for cpu
+    :returns: the kokkos module
+    """
+
+    if is_cpu:
+        return kokkos
+
+    return CONSTANTS["KOKKOS_GPU_MODULE"]
+
+def set_device_id(device_id: int) -> None:
+    """
+    Set the current device ID
+
+    :param device_id: the ID of the device to enable
+    """
+
+    if not isinstance(device_id, int):
+        raise TypeError("'device_id' must be of type 'int'")
+
+    num_gpus: int = CONSTANTS["NUM_GPUS"]
+    if device_id >= num_gpus or device_id < 0:
+        raise RuntimeError(f"Device {device_id} does not exist (range [0..{num_gpus})")
+
+    if num_gpus == 1:
+        return
+
+    import cupy
+    cupy.cuda.runtime.setDevice(device_id)
+    CONSTANTS["DEVICE_ID"] = device_id
+
+    gpu_lib = CONSTANTS["KOKKOS_GPU_MODULE_LIST"][device_id]
+    CONSTANTS["KOKKOS_GPU_MODULE"] = gpu_lib
+
+def get_device_id() -> int:
+    """
+    Get the ID of the currently enabled device
+
+    :returns: the ID of the enabled device
+    """
+
+    return CONSTANTS["DEVICE_ID"]
+
+def is_multi_gpu_enabled() -> bool:
+    """
+    Check if pykokkos has been configured for multi-gpu use
+
+    :returns: True or False
+    """
+
+    return CONSTANTS["MULTI_GPU"]
+
+def get_kokkos_gpu_modules() -> List:
+    """
+    Get the pykokkos-base gpu modules
+
+    :returns: the list of modules
+    """
+
+    return CONSTANTS["KOKKOS_GPU_MODULE_LIST"]
+
+def get_num_gpus() -> bool:
+    """
+    Get the number of gpus pykokkos has been configured for
+
+    :returns: the number of gpus
+    """
+
+    return CONSTANTS["NUM_GPUS"]
+
+try:
+    # Import multiple kokkos libs to support multiple devices per
+    # process. This assumes that there are modules named f"gpu{id}"
+    # that can be imported.
+    import atexit
+    import cupy as cp
+    import importlib
+    import sys
+
+    NUM_CUDA_GPUS: int = cp.cuda.runtime.getDeviceCount()
+    CONSTANTS["MULTI_GPU"] = True
+    CONSTANTS["NUM_GPUS"] = NUM_CUDA_GPUS
+    KOKKOS_LIBS: List[str] = [f"gpu{id}" for id in range(NUM_CUDA_GPUS)]
+
+    KOKKOS_LIB_INSTANCES: List = []
+    for id, lib in enumerate(KOKKOS_LIBS):
+        module = importlib.import_module(lib)
+        KOKKOS_LIB_INSTANCES.append(module)
+
+        # Can't pass device id directly to initialize(), so need to
+        # append argument to select device to sys.argv.
+        # (see https://github.com/kokkos/pykokkos-base/blob/d3946ed56483f3cbe2e660cc50fe73c50dad19ea/src/libpykokkos.cpp#L65)
+        sys.argv.append(f"--device-id={id}")
+        module.initialize()
+        atexit.register(module.finalize)
+        sys.argv.pop()
+
+    CONSTANTS["KOKKOS_GPU_MODULE_LIST"] = KOKKOS_LIB_INSTANCES
+    CONSTANTS["KOKKOS_GPU_MODULE"] = KOKKOS_LIB_INSTANCES[0]
+
+except Exception:
+    import traceback
+    traceback.print_exc()

--- a/pykokkos/kokkos_manager/__init__.py
+++ b/pykokkos/kokkos_manager/__init__.py
@@ -189,8 +189,6 @@ try:
     import sys
 
     NUM_CUDA_GPUS: int = cp.cuda.runtime.getDeviceCount()
-    CONSTANTS["MULTI_GPU"] = True
-    CONSTANTS["NUM_GPUS"] = NUM_CUDA_GPUS
     KOKKOS_LIBS: List[str] = [f"gpu{id}" for id in range(NUM_CUDA_GPUS)]
 
     KOKKOS_LIB_INSTANCES: List = []
@@ -206,9 +204,10 @@ try:
         atexit.register(module.finalize)
         sys.argv.pop()
 
+    CONSTANTS["MULTI_GPU"] = True
+    CONSTANTS["NUM_GPUS"] = NUM_CUDA_GPUS
     CONSTANTS["KOKKOS_GPU_MODULE_LIST"] = KOKKOS_LIB_INSTANCES
     CONSTANTS["KOKKOS_GPU_MODULE"] = KOKKOS_LIB_INSTANCES[0]
 
 except Exception:
-    import traceback
-    traceback.print_exc()
+    pass

--- a/pykokkos/lib/create.py
+++ b/pykokkos/lib/create.py
@@ -11,3 +11,22 @@ def ones(shape, *, dtype=None, device=None):
     view: pk.View = pk.View([*shape], dtype=dtype)
     view[:] = 1
     return view
+
+
+def ones_like(x, /, *, dtype=None, device=None):
+    if dtype is None:
+        dtype = x.dtype
+    view: pk.View = pk.View([*x.shape], dtype=dtype)
+    view[:] = 1
+    return view
+
+
+def full(shape, fill_value, *, dtype=None, device=None):
+    if dtype is None:
+        dtype = fill_value.dtype
+    try:
+        view: pk.View = pk.View([*shape], dtype=dtype)
+    except TypeError:
+        view: pk.View = pk.View([shape], dtype=dtype)
+    view[:] = fill_value
+    return view

--- a/pykokkos/lib/create.py
+++ b/pykokkos/lib/create.py
@@ -2,3 +2,12 @@ import pykokkos as pk
 
 def zeros(shape, *, dtype=None, device=None):
     return pk.View([*shape], dtype=dtype)
+
+
+def ones(shape, *, dtype=None, device=None):
+    if dtype is None:
+        # NumPy also defaults to a double for ones()
+        dtype = pk.float64
+    view: pk.View = pk.View([*shape], dtype=dtype)
+    view[:] = 1
+    return view

--- a/pykokkos/lib/info.py
+++ b/pykokkos/lib/info.py
@@ -36,6 +36,14 @@ def iinfo(type_or_arr):
         return info_type_attrs(bits=64,
                                min=-9223372036854775808,
                                max=9223372036854775807)
+    elif "uint8" in str(type_or_arr):
+        return info_type_attrs(bits=8,
+                               min=0,
+                               max=255)
+    elif "int8" in str(type_or_arr):
+        return info_type_attrs(bits=8,
+                               min=-128,
+                               max=127)
 
 
 def finfo(type_or_arr):

--- a/pykokkos/lib/manipulate.py
+++ b/pykokkos/lib/manipulate.py
@@ -1,0 +1,11 @@
+import pykokkos as pk
+
+import numpy as np
+
+
+def reshape(x, /, shape, *, copy=None):
+    view: pk.View = pk.View([*shape], dtype=x.dtype)
+    # TODO: write in a kernel/workunit and lean
+    # less on NumPy?
+    view[:] = np.reshape(x, shape)
+    return view

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1574,3 +1574,44 @@ def equal(view1, view2):
         raise NotImplementedError("equal ufunc not implemented for this comparison")
 
     return view_result
+
+
+@pk.workunit
+def isfinite_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+def isfinite(view):
+    out = pk.View([*view.shape], dtype=pk.uint8)
+    if "double" in str(view.dtype) or "float64" in str(view.dtype):
+        if view.shape == ():
+            new_view = pk.View([1], dtype=pk.double)
+            new_view[:] = view
+            pk.parallel_for(1,
+                            isfinite_impl_1d_double,
+                            view=new_view,
+                            out=out)
+        else:
+            pk.parallel_for(view.shape[0],
+                            isfinite_impl_1d_double,
+                            view=view,
+                            out=out)
+    elif "float" in str(view.dtype):
+        if view.shape == ():
+            new_view = pk.View([1], dtype=pk.float)
+            new_view[:] = view
+            pk.parallel_for(1,
+                            isfinite_impl_1d_float,
+                            view=new_view,
+                            out=out)
+        else:
+            pk.parallel_for(view.shape[0],
+                            isfinite_impl_1d_float,
+                            view=view,
+                            out=out)
+    return out

--- a/pykokkos/lib/util.py
+++ b/pykokkos/lib/util.py
@@ -13,7 +13,7 @@ def all(x, /, *, axis=None, keepdims=False):
     elif x == False:
         return False
     np_result = np.all(x)
-    ret_val = pk.View(pk.from_numpy(np.all(x)))
+    ret_val = pk.from_numpy(np_result)
     return ret_val
 
 

--- a/runtests.py
+++ b/runtests.py
@@ -19,10 +19,13 @@ pytest_args = []
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-t', '--specifictests', type=str)
+parser.add_argument('-d', '--durations', type=int)
 args = parser.parse_args()
 
 if args.specifictests:
     pytest_args.append(args.specifictests)
+if args.durations:
+    pytest_args.append(f"--durations={args.durations}")
 
 # force pytest to actually import
 # all the test modules directly

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,7 +9,7 @@ except ImportError:
     HAS_CUDA = False
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 import pykokkos as pk
 
 
@@ -355,6 +355,21 @@ def test_asarray_consts_vs_numpy(const, np_dtype, pk_dtype):
     # none of the final types for these float
     # constants should ever be allowed to be ints
     assert not "int" in pk_type_string
+
+
+
+@pytest.mark.parametrize("pk_dtype, np_dtype", [
+    (pk.uint8, np.uint8),
+    (pk.uint16, np.uint16),
+    (pk.uint32, np.uint32),
+    (pk.uint64, np.uint64),
+    ])
+def test_unsigned_int_overflow(pk_dtype, np_dtype):
+    # test for gh-86
+    actual = pk.View([1], dtype=pk_dtype)
+    actual[:] = -1
+    expected = np.array(-1, dtype=np_dtype)
+    assert_equal(actual, expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR enables using multiple CUDA GPUs in PyKokkos in the same process. It depends on another `pykokkos-base` [PR](https://github.com/kokkos/pykokkos-base/pull/48) which makes multiple copies of `libpykokkos`, `libkokkoscore`, and `libkokkoscontainers`. PyKokkos will then link kernels compiled for CUDA to a different set of libraries depending on the GPU specified by the user.

The concept of Multi-GPU Kokkos is based on William Ruys's work [here](https://github.com/ut-parla/Parla.py/tree/main/examples/kokkos) 