### PR TITLE
MAINT, BUG: typing cleanups

### DIFF
--- a/pykokkos/interface/data_types.py
+++ b/pykokkos/interface/data_types.py
@@ -58,12 +58,12 @@ class uint16(DataTypeClass):
 
 
 class uint32(DataTypeClass):
-    value = kokkos.int32
+    value = kokkos.uint32
     np_equiv = np.uint32
 
 
 class uint64(DataTypeClass):
-    value = kokkos.int64
+    value = kokkos.uint64
     np_equiv = np.uint64
 
 

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -280,14 +280,6 @@ class View(ViewType):
             self.dtype = DataType.float
         elif self.dtype == pk.double:
             self.dtype = DataType.double
-        elif self.dtype == pk.int32:
-            self.dtype = DataType.int32
-        elif self.dtype == pk.int64:
-            pass
-        elif self.dtype == pk.uint32:
-            self.dtype = DataType.uint32
-        elif self.dtype == pk.uint64:
-            self.dtype = DataType.uint64
         if trait is trait.Unmanaged:
             if array is not None and array.ndim == 0:
                 # TODO: we don't really support 0-D under the hood--use


### PR DESCRIPTION
* this splits off a few cleanups from gh-73

* there is some pointless type remapping code in the `View` class that has been removed

* removing the above code causes the test suite to fail because of incorrect `uint32`/`uint64`
`value` mappings in `data_types` module, so fix
those to allow tests to pass