### PR TITLE
TST, MAINT: test durations

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -19,10 +19,13 @@ pytest_args = []
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-t', '--specifictests', type=str)
+parser.add_argument('-d', '--durations', type=int)
 args = parser.parse_args()
 
 if args.specifictests:
     pytest_args.append(args.specifictests)
+if args.durations:
+    pytest_args.append(f"--durations={args.durations}")
 
 # force pytest to actually import
 # all the test modules directly


### PR DESCRIPTION
* add an option to report the top `N` slowest tests when running `runtests.py`, which basically
just passes through to the built-in pytest option: https://docs.pytest.org/en/7.1.x/how-to/usage.html#profiling-test-execution-duration

* I'm hoping not to build many more options in though, I just wanted this one because we'll want a convenient way to keep an eye on what tests are consuming time as our suite grows

* some sample incantations/results:

- `python runtests.py -d 10`

```
===================================================================================================================================================
slowest 10 durations
===================================================================================================================================================
11.51s call    tests/test_ufuncs.py::test_caching
11.21s call    tests/test_hierarchical.py::TestHierarchical::test_outer_for
9.23s call     tests/test_AST_translator.py::TestASTTranslator::test_ann_assign
7.95s call     tests/test_kokkosfunctions_translator.py::TestKokkosFunctionsTranslator::test_args_sum
7.83s call     tests/test_atomics.py::TestAtomic::test_atomic_add
6.27s call     tests/test_ops_translator.py::TestOpsTranslator::test_add_op
5.36s call     tests/test_hierarchical.py::TestHierarchical::test_yAx_vector
5.10s call     tests/test_ufuncs.py::test_matmul_1d_exposed_ufuncs_vs_numpy[double-float64-matmul-matmul]
5.08s call     tests/test_ufuncs.py::test_matmul_1d_exposed_ufuncs_vs_numpy[float-float32-matmul-matmul]
4.92s call     tests/test_ufuncs.py::test_multi_array_1d_exposed_ufuncs_vs_numpy[float-float32-greater-greater]
============================================================================================================================
203 passed, 9 skipped, 9 xfailed, 16 warnings in 450.11s (0:07:30)
    ============================================================================================================================

```

- `python runtests.py -d 5 -t tests/test_views.py`

```
===================================================================================================================================================
slowest 5 durations
====================================================================================================================================================
0.02s call    tests/test_views.py::test_asarray_consts_vs_numpy[None-None-nan]
0.02s call    tests/test_views.py::test_sizes[input_arr2-view_dims2-View3D]
0.02s call    tests/test_views.py::test_asarray_consts_vs_numpy[int32-int32-2.718281828459045]
0.02s call    tests/test_views.py::test_sizes[input_arr1-view_dims1-View2D]
0.02s call    tests/test_views.py::test_asarray_consts_vs_numpy[int64-int64-2.718281828459045]
==============================================================================================================================================
31 passed, 9 skipped in 0.78s
   ===============================================================================================================================================

```