### PR TITLE
ENH: support result_type

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like array_api_tests/test_data_type_functions.py::test_result_type

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -50,7 +50,7 @@ from .views import (
     ScratchView3D, ScratchView4D, ScratchView5D,
     ScratchView6D, ScratchView7D, ScratchView8D,
     from_cupy, from_numpy,
-    asarray,
+    asarray, result_type,
 )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -372,5 +372,30 @@ def test_unsigned_int_overflow(pk_dtype, np_dtype):
     assert_equal(actual, expected)
 
 
+@pytest.mark.parametrize("pk_dtype, pk_dtype2, expected_promo", [
+    (pk.uint8, pk.uint16, pk.uint16),
+    (pk.uint64, pk.uint8, pk.uint64),
+    (pk.float32, pk.float64, pk.float64),
+    ])
+def test_result_type_supported(pk_dtype, pk_dtype2, expected_promo):
+    # some basic behavior should already be covered
+    # by:
+    # array_api_tests/test_data_type_functions.py::test_result_type
+    actual = pk.result_type(pk_dtype, pk_dtype2)
+    assert actual == expected_promo
+
+
+@pytest.mark.parametrize("pk_dtype, pk_dtype2", [
+    (pk.from_numpy(np.array([0])), pk.uint16),
+    (pk.uint64, pk.int8),
+    (pk.float32, pk.int64),
+    ])
+def test_result_type_unsupported(pk_dtype, pk_dtype2):
+    # support for views (arrays) and mixed type
+    # categories is not yet available
+    with pytest.raises(NotImplementedError):
+        pk.result_type(pk_dtype, pk_dtype2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* add changes needed to support the array API data type function `result_type()`, which is tested by
`array_api_tests/test_data_type_functions.py::test_result_type` and described in the standard at:
  - https://data-apis.org/array-api/latest/API_specification/generated/signatures.data_type_functions.result_type.html?highlight=result_type
  - https://data-apis.org/array-api/latest/API_specification/type_promotion.html#type-promotion

* surprisingly, this relatively simple draft logic already passes the array API test, but I'm certain this is far too simple to handle all cases for us beyond the simplest ones; still, it is a start on our type promotion rules

* I don't think this will work with views yet (or what we'll eventually call arrays), but it seems to pass the dtype tests used by the conformance suite at least