### PR TITLE
ENH: log10 to API standard

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -45,4 +45,4 @@ jobs:
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
           # only run a subset of the conformance tests to get started
-          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like array_api_tests/test_data_type_functions.py::test_result_type
+          pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like array_api_tests/test_data_type_functions.py::test_result_type array_api_tests/test_operators_and_elementwise_functions.py::test_log10


### PR DESCRIPTION
* changes needed to pass `array_api_tests/test_operators_and_elementwise_functions.py::test_log10`, and start testing this in our CI

* this brings our `log10` ufunc closer to the array API standard based on the above test from their conformance suite; we handle 0-D and 2-D input for this ufunc now as well (as the test required)

* I'm not so sure we actually want to dispatch to any kind of parallel kernel for 0-D input to be honest, but I've done this for now...

* we no longer mutate input views for `log10` (more similar to NumPy..), instead allocating a new one to assign the result to

* `Subview`s were missing a few attributes required to pass the above test

* the test required that I start adding basic support for converting size-1 `View` objects like `[0]` to Python scalars via `float(view)`, so I've done something similar to NumPy in this regard