### PR TITLE
MAINT, CI: Python 3.11 rc2

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10.6", "3.11.0-rc.1"]
+        python-version: ["3.8", "3.9", "3.10.6", "3.11.0-rc.2"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
* bump CI testing to Python `3.11rc2`--the final release is just a few weeks away now

* as reminder, the Python release candidates are considered both API and ABI stable vs. final release:
https://www.python.org/downloads/release/python-3110rc2/

* I doubt we'll see anything change from rc1->rc2 on our end, by why not check I guess