### PR TITLE
WIP, MAINT: pre-compile ufuncs

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -49,6 +49,6 @@ jobs:
           # to circumvent the currently slow performance of
           # JIT compile/link, which can otherwise cause issues
           # for hypothesis-driven test case generation
-          python $GITHUB_WORKSPACE/pre_compile_tools/pre_compile_ufuncs.py
+          pytest $GITHUB_WORKSPACE/pre_compile_tools/pre_compile_ufuncs.py -s
           # only run a subset of the conformance tests to get started
           pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like array_api_tests/test_data_type_functions.py::test_result_type array_api_tests/test_operators_and_elementwise_functions.py::test_log10

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -43,6 +43,7 @@ jobs:
           git checkout 4d9d7b4b73c
           git submodule update --init
           pip install -r requirements.txt
+          pip install "hypothesis==6.54.5"
           export ARRAY_API_TESTS_MODULE=pykokkos
           # we precompile some of the ufunc implementations
           # to circumvent the currently slow performance of

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy cmake pytest pybind11 scikit-build patchelf tqdm
       - name: Install pykokkos-base
         run: |
           cd /tmp
@@ -44,5 +44,10 @@ jobs:
           git submodule update --init
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos
+          # we precompile some of the ufunc implementations
+          # to circumvent the currently slow performance of
+          # JIT compile/link, which can otherwise cause issues
+          # for hypothesis-driven test case generation
+          python $GITHUB_WORKSPACE/pre_compile_tools/pre_compile_ufuncs.py
           # only run a subset of the conformance tests to get started
           pytest array_api_tests/meta/test_broadcasting.py array_api_tests/meta/test_equality_mapping.py array_api_tests/meta/test_signatures.py array_api_tests/meta/test_special_cases.py array_api_tests/test_constants.py array_api_tests/meta/test_utils.py array_api_tests/test_creation_functions.py::test_ones array_api_tests/test_creation_functions.py::test_ones_like array_api_tests/test_data_type_functions.py::test_result_type array_api_tests/test_operators_and_elementwise_functions.py::test_log10

--- a/pre_compile_tools/pre_compile_ufuncs.py
+++ b/pre_compile_tools/pre_compile_ufuncs.py
@@ -1,0 +1,52 @@
+"""
+The purpose of this module is to pre-compile
+all ufunc implementations for cases where
+the overhead from the JIT workflow causes
+intractable slowdowns. A common use case
+is the hypothesis library-driven generation
+of large sets of test cases in the array API
+conformance test suite.
+"""
+
+from inspect import getmembers, isfunction
+import logging
+
+import pykokkos as pk
+from pykokkos.lib import ufuncs
+
+from tqdm import tqdm
+
+
+def main():
+    # disable logging of translation/compile times
+    # to get a nice clean progress bar for the overall
+    # ufunc compile progress
+    logging.disable(logging.INFO)
+    function_list = getmembers(ufuncs, isfunction)
+    # only call the parent ufunc, not the lower
+    # level kernels/workunits directly
+    filtered_function_list = []
+    for f in function_list:
+        if not "impl" in f[0]:
+            filtered_function_list.append(f)
+    # TODO: expand types and view dimensions for
+    # ufunc pre-compilation as the support
+    # grows more broadly for more dims and types in ufuncs
+    v = pk.View([2], dtype=pk.double)
+    v2 = pk.View([2, 1], dtype=pk.double)
+    for func in tqdm(filtered_function_list):
+        func_obj = func[1]
+        # try compiling the ufunc as binary, then
+        # as unary if that fails
+        try:
+            func_obj(v, v)
+        except TypeError:
+            func_obj(v)
+        except RuntimeError:
+            # some cases like matmul have stricter
+            # signature requirements
+            func_obj(v, v2)
+
+
+if __name__ == "__main__":
+    main()

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -86,6 +86,8 @@ def log(view):
         Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("log() ufunc only supports 1D views")
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], log_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
@@ -125,6 +127,8 @@ def sqrt(view):
     """
     # TODO: support complex types when they
     # are available in pykokkos?
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for sqrt() ufunc.")
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], sqrt_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
@@ -157,6 +161,8 @@ def log2(view):
         Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("log2() ufunc only supports 1D views")
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], log2_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
@@ -248,6 +254,8 @@ def log1p(view):
         Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("log1p() ufunc only supports 1D views")
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], log1p_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
@@ -280,6 +288,8 @@ def sign_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
 
 
 def sign(view):
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for sign() ufunc.")
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], sign_impl_1d_double, view=view)
     elif str(view.dtype) == "DataType.float":
@@ -316,6 +326,8 @@ def add(viewA, viewB):
 
     """
 
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for add() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -367,6 +379,8 @@ def multiply(viewA, viewB):
 
     """
 
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for mulitply() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -417,6 +431,8 @@ def subtract(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for subtract() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -513,6 +529,8 @@ def divide(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for divide() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -559,12 +577,16 @@ def negative(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for negative() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], negative_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], negative_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -593,12 +615,16 @@ def positive(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for positive() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], positive_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], positive_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -630,6 +656,8 @@ def power(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for power() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -681,6 +709,8 @@ def fmod(viewA, viewB):
 
     """
 
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("fmod() ufunc only supports 1D views")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -727,6 +757,8 @@ def square(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for square() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(
@@ -774,6 +806,8 @@ def greater(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("greater() ufunc only supports 1D views")
     out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
@@ -823,6 +857,8 @@ def logaddexp(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logaddexp() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -893,6 +929,8 @@ def logaddexp2(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logaddexp2() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -943,6 +981,8 @@ def floor_divide(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for floor_divide() ufunc.")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -990,12 +1030,16 @@ def sin(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for sin() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], sin_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], sin_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -1024,12 +1068,16 @@ def cos(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for cos() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], cos_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], cos_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -1058,12 +1106,16 @@ def tan(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for tan() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], tan_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], tan_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -1094,6 +1146,8 @@ def logical_and(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logical_and() ufunc.")
     out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
@@ -1142,6 +1196,8 @@ def logical_or(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logical_or() ufunc.")
     out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
@@ -1190,6 +1246,8 @@ def logical_xor(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logical_xor() ufunc.")
     out = pk.View([viewA.shape[0]], pk.uint8)
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         pk.parallel_for(
@@ -1236,6 +1294,8 @@ def logical_not(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for logical_not() ufunc.")
     out = pk.View([view.shape[0]], pk.uint8)
     if str(view.dtype) == "DataType.double":
         pk.parallel_for(view.shape[0], logical_not_impl_1d_double, view=view, out=out)
@@ -1271,6 +1331,8 @@ def fmax(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("fmax() ufunc only supports 1D views")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -1320,6 +1382,8 @@ def fmin(viewA, viewB):
            Output view.
 
     """
+    if len(viewA.shape) > 1 or len(viewB.shape) > 1:
+        raise NotImplementedError("fmax() ufunc only supports 1D views")
     if str(viewA.dtype) == "DataType.double" and str(viewB.dtype) == "DataType.double":
         out = pk.View([viewA.shape[0]], pk.double)
         pk.parallel_for(
@@ -1367,12 +1431,16 @@ def exp(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for exp() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], exp_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], exp_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -1401,12 +1469,16 @@ def exp2(view):
            Output view.
 
     """
+    if len(view.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for exp2() ufunc.")
     if str(view.dtype) == "DataType.double":
         out = pk.View([view.shape[0]], pk.double)
         pk.parallel_for(view.shape[0], exp2_impl_1d_double, view=view, out=out)
     elif str(view.dtype) == "DataType.float":
         out = pk.View([view.shape[0]], pk.float)
         pk.parallel_for(view.shape[0], exp2_impl_1d_float, view=view, out=out)
+    else:
+        raise NotImplementedError
     return out
 
 
@@ -1421,6 +1493,8 @@ def isnan_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.u
 
 
 def isnan(view):
+    if len(view.shape) > 1:
+        raise NotImplementedError("isnan() ufunc only supports 1D views")
     out = pk.View([*view.shape], dtype=pk.uint8)
     if "double" in str(view.dtype) or "float64" in str(view.dtype):
         pk.parallel_for(view.shape[0],
@@ -1446,6 +1520,8 @@ def isinf_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.u
 
 
 def isinf(view):
+    if len(view.shape) > 1:
+        raise NotImplementedError("isinf() ufunc only supports 1D views")
     out = pk.View([*view.shape], dtype=pk.uint8)
     if "double" in str(view.dtype) or "float64" in str(view.dtype):
         pk.parallel_for(view.shape[0],
@@ -1548,6 +1624,10 @@ def equal(view1, view2):
     # have different, but comparable, types (like float32 vs. float64?)
     # this may "explode" without templating
 
+    # array API suite will fail if we check view1.shape here...
+    if len(view2.shape) > 1:
+        raise NotImplementedError("only 1D views currently supported for equal() ufunc.")
+
     if sum(view1.shape) == 0 or sum(view2.shape) == 0:
         return np.empty(shape=(0,))
 
@@ -1614,6 +1694,8 @@ def isfinite_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[p
 
 
 def isfinite(view):
+    if len(view.shape) > 1:
+        raise NotImplementedError("isfinite() ufunc only supports 1D views")
     out = pk.View([*view.shape], dtype=pk.uint8)
     if "double" in str(view.dtype) or "float64" in str(view.dtype):
         if view.shape == ():


### PR DESCRIPTION
* as discussed briefly on Slack, this is a draft branch for precompiling a subset of the ufuncs
to avoid JIT slowdown errors like the one
described here for the `hypothesis`-driven array
API conformance test suite:
https://github.com/kokkos/pykokkos/pull/97#issuecomment-1261624809

* for now, this focuses on `pk.double` type in a single dimension, simply because all ufuncs should support that for pre-compilation at this time (we can broaden the dim/type pre-compile as ufuncs gain more flexibile type/dim support)

* one major issue I see here is that I don't think the pre-compilation will actually do anything useful yet because of how the `pk_cpp` directory structures work on a per-module non-shared hierarchy basis:

- pre-compilation module `pk_cpp` hierarchy:
![image](https://user-images.githubusercontent.com/7903078/193139812-0789ed89-3de5-4b70-a851-dc728ea4a486.png)
- `pytest` `pk_cpp` hierarchy:
![image](https://user-images.githubusercontent.com/7903078/193139828-b5d66ddc-3cca-4a9e-add9-1289842a271b.png)
