### PR TITLE
added compiler_path when using env variable to point to kokkos install

### DIFF
--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -146,7 +146,13 @@ class CppSetup:
             if not include_path.is_dir():
                 raise RuntimeError(f"install/ directory path {str(include_path)} does not exist")
 
-            return lib_path, include_path
+            compiler_path: Path
+            if compiler != "nvcc":
+                compiler_path = Path("g++")
+            else:
+                compiler_path = lib_path.parent / "bin/nvcc_wrapper"
+
+            return lib_path, include_path, compiler_path
 
         is_cpu: bool = is_host_execution_space(space)
         kokkos_lib: ModuleType = km.get_kokkos_module(is_cpu)


### PR DESCRIPTION
The tuple the function should return should contain 3 paths but never did when pykokkos is configured to use an external Kokkos lib via `PK_KOKKOS_LIB_PATH`. Came up because ArborX uses Kokkos 3.6.01