### PR TITLE
Make pykokkos export bindings for the generated functor

### DIFF
--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -380,9 +380,35 @@ def generate_kernel(
 
     return kernel
 
-def bind_wrappers(module: str, wrappers: List[str]) -> str:
+def bind_wrapper(variable: str, wrapper: str) -> str:
     """
     Generate the binding code for all wrappers
+
+    :returns: the binding code
+    """
+
+    binding = f"{variable}.def(\"{wrapper}\", &{wrapper});"
+
+    return binding
+
+def bind_functor(
+    variable: str,
+    functor: str) -> List[str]:
+    """
+    Generates the bindings for a functor.
+
+    :param variable: the name of the module variable
+    :param functor: the functor class name
+    :returns: the binding code
+    """
+    binding = f"pybind11::class_<{functor}>({variable},\"{functor}\")"
+    binding += f".def(pybind11::init<>());"
+
+    return binding
+
+def bind_module(module: str, wrappers: List[str], functor: str) -> str:
+    """
+    Generate the binding code for all wrappers and the functor
 
     :returns: the binding code
     """
@@ -390,7 +416,10 @@ def bind_wrappers(module: str, wrappers: List[str]) -> str:
     variable: str = "k"
     binding: str = f"PYBIND11_MODULE({module}, {variable}) {{"
     for w in wrappers:
-        binding += f"{variable}.def(\"{w}\", &{w});"
+        binding += bind_wrapper(variable,w)
+
+    binding += bind_functor(variable,functor)
+
     binding += "}"
 
     return binding
@@ -473,7 +502,7 @@ def bind_workunits(
         bindings.extend(b)
         wrapper_names.extend(w)
 
-    bindings.append(bind_wrappers(module, wrapper_names))
+    bindings.append(bind_module(module, wrapper_names,functor))
 
     return bindings
 
@@ -595,6 +624,6 @@ def bind_main(
         bindings.append(b)
         wrapper_names.append(w)
 
-    bindings.append(bind_wrappers(module, wrapper_names))
+    bindings.append(bind_module(module, wrapper_names,functor))
 
     return bindings

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -382,7 +382,7 @@ def generate_kernel(
 
 def bind_wrapper(variable: str, wrapper: str) -> str:
     """
-    Generate the binding code for all wrappers
+    Generate the binding code for a wrapper
 
     :returns: the binding code
     """
@@ -408,7 +408,7 @@ def bind_functor(
 
 def bind_module(module: str, wrappers: List[str], functor: str) -> str:
     """
-    Generate the binding code for all wrappers and the functor
+    Generate the binding code for all wrappers and the functor (aka the module)
 
     :returns: the binding code
     """

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -391,9 +391,7 @@ def bind_wrapper(variable: str, wrapper: str) -> str:
 
     return binding
 
-def bind_functor(
-    variable: str,
-    functor: str) -> List[str]:
+def bind_functor(variable: str,functor: str) -> List[str]:
     """
     Generates the bindings for a functor.
 

--- a/pykokkos/core/translators/functor.py
+++ b/pykokkos/core/translators/functor.py
@@ -147,6 +147,21 @@ def generate_constructor(
 
     return cppast.ConstructorDecl("", name, params, body)
 
+def generate_default_constructor(
+    name: str,
+) -> cppast.ConstructorDecl:
+    """
+    Generate the functor default constructor
+
+    :param name: the functor class name
+    :returns: the cppast representation of the default constructor
+    """
+
+    assignments: List[cppast.AssignOperator] = []
+    body = cppast.CompoundStmt(assignments)
+    params: List[cppast.ParmVarDecl] = []
+
+    return cppast.ConstructorDecl("", name, params, body)
 
 def generate_functor(
     name: str,
@@ -194,6 +209,7 @@ def generate_functor(
         decls.append(cppast.DeclStmt(cppast.FieldDecl(f"Kokkos::{pool_type}<>", pool_name)))
 
     decls.append(generate_constructor(name, fields, views, random_pool, has_rand_call))
+    decls.append(generate_default_constructor(name))
     for _, s in workunits.values():
         decls.append(s)
 


### PR DESCRIPTION
From a discussion I had with @NaderAlAwar about extending the interoperability with C++. The main reasoning was the following:
If we let people write their functors in python and expose the generated C++ functors (incl. bindings) we enable people to use pybind for generating wrappers. Anyone who uses pykokkos for creating a binding to a C++ library that uses kokkos can use the functors as arguments to calls to his C++ library and then bind them. Basically we allow people to export functors (and thus algorithms/logic) into bindings of their own C++ libs.

Some considerations:

- Our functor requires every argument to be default constructible ... we should document that. We would not necessarily have to allow this but that is how it is at the moment.
- Thus it is no problem to also allow the generation of a default constructor which enables us to generate python bindings for the class. 
- Next step would be generate a cast operator from the python into the c++ instance so we do not copy data every time we switch to C++
