### PR TITLE
ENH: add __array_api_version__

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -43,7 +43,6 @@ jobs:
           git checkout 4d9d7b4b73c
           git submodule update --init
           pip install -r requirements.txt
-          pip install "hypothesis==6.54.5"
           export ARRAY_API_TESTS_MODULE=pykokkos
           # we precompile some of the ufunc implementations
           # to circumvent the currently slow performance of

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -66,6 +66,10 @@ from pykokkos.lib.manipulate import reshape
 from pykokkos.lib.util import all, any, sum, find_max, searchsorted
 from pykokkos.lib.constants import e, pi, inf, nan
 
+__array_api_version__ = "2021.12"
+
+__all__ = ["__array_api_version__"]
+
 runtime_singleton.runtime = Runtime()
 defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()
 

--- a/pykokkos/lib/info.py
+++ b/pykokkos/lib/info.py
@@ -23,15 +23,29 @@ def iinfo(type_or_arr):
     # so we can run the array API tests,
     # and effectively just copies return
     # values from the NumPy equivalent
+    if "uint32" in str(type_or_arr):
+        return info_type_attrs(bits=32,
+                               min=0,
+                               max=4294967295)
     if "int32" in str(type_or_arr):
         return info_type_attrs(bits=32,
                                max=2147483647,
                                min=-2147483648)
+    elif "uint16" in str(type_or_arr):
+        # iinfo(min=0, max=65535, dtype=uint16)
+        return info_type_attrs(bits=16,
+                               min=0,
+                               max=65535)
     elif "int16" in str(type_or_arr):
         # iinfo(min=-32768, max=32767, dtype=int16)
         return info_type_attrs(bits=16,
                                min=-32768,
                                max=32767)
+    elif "uint64" in str(type_or_arr):
+        # iinfo(min=0, max=18446744073709551615, dtype=uint64)
+        return info_type_attrs(bits=64,
+                               min=0,
+                               max=18446744073709551615)
     elif "int64" in str(type_or_arr):
         return info_type_attrs(bits=64,
                                min=-9223372036854775808,


### PR DESCRIPTION
* this is in part a copy of the NumPy patch applied at: https://github.com/numpy/numpy/pull/22365
and is related to this failure we were seeing with `hypothesis`: https://github.com/kokkos/pykokkos/issues/65#issuecomment-1262840467

* the standard section related to this is: https://data-apis.org/array-api/latest/future_API_evolution.html#versioning

* unpin `hypothesis` in our CI as a result; to be fair, this is the solution @ShahzadUmair wanted from the start I think

* the updated testing behavior required me to cherry-pick some data type info improvements from gh-97