### PR TITLE
CI: unpin Python 3.10

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10.6", "3.11.0-rc.2"]
+        python-version: ["3.8", "3.9", "3.10", "3.11.0-rc.2"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #83

* we should no longer need to pin to Python `3.10.6` in CI based on the
discussion I'm seeing upstream (see link in matching issue)