### PR TITLE
Functor cast operators for interoperability with c++

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -92,6 +92,9 @@ ignore_errors = True
 [mypy-pykokkos.core.translators.bindings]
 ignore_errors = True
 
+[mypy-pykokkos.core.translators.functor_cast]
+ignore_errors = True
+
 [mypy-pykokkos.lib.ufuncs]
 ignore_errors = True
 

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -38,6 +38,7 @@ class Compiler:
         self.parser_cache: Dict[str, Parser] = {}
 
         self.functor_file: str = "functor.hpp"
+        self.functor_cast_file: str = "functor_cast.hpp"
         self.bindings_file: str = "bindings.cpp"
         self.defaults_file: str = "defaults.json"
 
@@ -178,19 +179,20 @@ class Compiler:
         if module_setup.is_compiled():
             return
 
-        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files, self.functor_file, self.bindings_file)
-        translator = StaticTranslator(module_setup.name, self.functor_file, members)
+        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files, self.functor_file,self.functor_cast_file, self.bindings_file)
+        translator = StaticTranslator(module_setup.name, self.functor_file,self.functor_cast_file, members)
 
         t_start: float = time.perf_counter()
         functor: List[str]
         bindings: List[str]
-        functor, bindings = translator.translate(entity, classtypes)
+        cast: List[str]
+        functor, bindings, cast = translator.translate(entity, classtypes)
         t_end: float = time.perf_counter() - t_start
         self.logger.info(f"translation {t_end}")
 
         output_dir: Path = module_setup.get_output_dir(main, module_setup.metadata, space)
         c_start: float = time.perf_counter()
-        cpp_setup.compile(output_dir, functor, bindings, space, force_uvm, self.get_compiler())
+        cpp_setup.compile(output_dir, functor, cast, bindings, space, force_uvm, self.get_compiler())
         c_end: float = time.perf_counter() - c_start
         self.logger.info(f"compilation {c_end}")
 

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -18,7 +18,7 @@ class CppSetup:
     Creates the directory to hold the translation and invokes the compiler
     """
 
-    def __init__(self, module_file: str, gpu_module_files: List[str], functor: str, bindings: str):
+    def __init__(self, module_file: str, gpu_module_files: List[str], functor: str,functor_cast: str, bindings: str):
         """
         CppSetup constructor
 
@@ -31,6 +31,7 @@ class CppSetup:
         self.module_file: str = module_file
         self.gpu_module_files: List[str] = gpu_module_files
         self.functor_file: str = functor
+        self.functor_cast_file: str = functor_cast
         self.bindings_file: str = bindings
 
         self.script: str = "compile.sh"
@@ -44,6 +45,7 @@ class CppSetup:
         self,
         output_dir: Path,
         functor: List[str],
+        functor_cast: List[str],
         bindings: List[str],
         space: ExecutionSpace,
         enable_uvm: bool,
@@ -60,7 +62,7 @@ class CppSetup:
         """
 
         self.initialize_directory(output_dir)
-        self.write_source(output_dir, functor, bindings)
+        self.write_source(output_dir, functor, functor_cast, bindings)
         self.copy_script(output_dir)
         self.invoke_script(output_dir, space, enable_uvm, compiler)
         if space is ExecutionSpace.Cuda and km.is_multi_gpu_enabled():
@@ -84,7 +86,7 @@ class CppSetup:
         except FileExistsError:
             pass
 
-    def write_source(self, output_dir: Path, functor: List[str], bindings: List[str]) -> None:
+    def write_source(self, output_dir: Path, functor: List[str], functor_cast: List[str], bindings: List[str]) -> None:
         """
         Writes the generated C++ source code to a file
 
@@ -94,16 +96,20 @@ class CppSetup:
         """
 
         functor_path: Path = output_dir.parent / self.functor_file
+        functor_cast_path: Path = output_dir.parent / self.functor_cast_file
         bindings_path: Path = output_dir / self.bindings_file
 
         with open(functor_path, "w") as out:
             out.write("\n".join(functor))
+        with open(functor_cast_path, "w") as out:
+            out.write("\n".join(functor_cast))
         with open(bindings_path, "w") as out:
             out.write("\n".join(bindings))
 
         if self.format:
             try:
                 subprocess.run(["clang-format", "-i", functor_path])
+                subprocess.run(["clang-format", "-i", functor_cast_path])
                 subprocess.run(["clang-format", "-i", bindings_path])
             except Exception as ex:
                 print(f"Exception while formatting cpp: {ex}")

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -124,14 +124,14 @@ def get_device_views(members: PyKokkosMembers) -> Dict[str, str]:
     return {v.declname: f"pk_d_{v.declname}" for v in members.views \
             if members.views[v] is not None}
 
-def generate_functor_instance(functor: str, members: PyKokkosMembers, with_random_args: bool=True, functorExecSpace: Optional[str] = None) -> str:
+def generate_functor_instance(functor: str, members: PyKokkosMembers, with_random_args: bool=True, functor_exec_space: Optional[str] = None) -> str:
     """
     Generate the functor instance
 
     :param functor: the name of the functor
     :param members: an object containing the fields and views
     :param with_random_args: bool indicating if the constructor call should have the random args. default = True
-    :param functorExecSpace: optional parameter of type str that contains the ExecSpace template argument to the functor
+    :param functor_exec_space: optional parameter of type str that contains the ExecSpace template argument to the functor
     :returns: the source code for instantiating the functor
     """
 
@@ -140,11 +140,11 @@ def generate_functor_instance(functor: str, members: PyKokkosMembers, with_rando
     for f in members.fields:
         args.append(f.declname)
 
-    if functorExecSpace is None:
+    if functor_exec_space is None:
         exec_space: str = Keywords.DefaultExecSpace.value
         exec_space_instance: str = Keywords.DefaultExecSpaceInstance.value
     else:
-        exec_space: str = functorExecSpace
+        exec_space: str = functor_exec_space
         exec_space_instance: str = f"{exec_space}_instance"
 
     mirror_views: str = f"{exec_space} {exec_space_instance};"

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -48,7 +48,7 @@ def get_view_memory_space(view_type: cppast.ClassType, location: str) -> str:
                 return f"Kokkos::{name}"
 
     if location == "functor":
-        return f"ExecutionSpace::memory_space"
+        return f"typename ExecSpace::memory_space"
     if location == "bindings":
         return Keywords.ArgMemSpace.value
 
@@ -383,7 +383,9 @@ def generate_kernel(
         acc = f"{return_type} {Keywords.Accumulator.value} = 0;"
 
     if members.has_real:
-        functor += f"<{real}>"
+        functor += f"<{Keywords.DefaultExecSpace.value},{real}>"
+    else:
+        functor += f"<{Keywords.DefaultExecSpace.value}>"
 
     instance: str = generate_functor_instance(functor, members)
     call: str = generate_call(operation, functor, members, tag, hierarchical)

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -130,6 +130,8 @@ def generate_functor_instance(functor: str, members: PyKokkosMembers, with_rando
 
     :param functor: the name of the functor
     :param members: an object containing the fields and views
+    :param with_random_args: bool indicating if the constructor call should have the random args. default = True
+    :param functorExecSpace: optional parameter of type str that contains the ExecSpace template argument to the functor
     :returns: the source code for instantiating the functor
     """
 

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -546,7 +546,9 @@ def bind_main_single(
         real = visitors_util.view_dtypes[precision.name].value
         wrapper_name += f"_{real}"
         kernel_name += f"_{real}"
-        functor += f"<{real}>"
+        functor += f"<{Keywords.DefaultExecSpace.value},{real}>"
+    else:
+        functor += f"<{Keywords.DefaultExecSpace.value}>"
 
     main: List[str] = translate_mains(source, functor, members, pk_import)
     params: Dict[str, str] = get_kernel_params(members, False, True, real)

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -48,7 +48,7 @@ def get_view_memory_space(view_type: cppast.ClassType, location: str) -> str:
                 return f"Kokkos::{name}"
 
     if location == "functor":
-        return f"{Keywords.DefaultExecSpace.value}::memory_space"
+        return f"ExecutionSpace::memory_space"
     if location == "bindings":
         return Keywords.ArgMemSpace.value
 

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -156,7 +156,7 @@ def generate_functor_instance(functor: str, members: PyKokkosMembers, with_rando
     if len(args) == 0:
         args.append("0")
 
-    if(with_random_args):
+    if with_random_args:
         args.append(Keywords.RandPoolSeed.value)
         args.append(Keywords.RandPoolNumStates.value)
 

--- a/pykokkos/core/translators/functor.py
+++ b/pykokkos/core/translators/functor.py
@@ -17,7 +17,7 @@ def get_view_type(view: cppast.ClassType) -> str:
     """
 
     space: str = get_view_memory_space(view, "functor")
-    layout: str = f"{Keywords.DefaultExecSpace.value}::array_layout"
+    layout: str = f"ExecutionSpace::array_layout"
     view_type: str = cpp_view_type(view, space=space, layout=layout)
 
     return view_type
@@ -246,6 +246,7 @@ def generate_functor(
     struct = cppast.RecordDecl(cppast.ClassType(name), decls)
     struct.is_definition = True
 
+    struct.add_template_param("ExecutionSpace")
     if members.has_real:
         struct.add_template_param(Keywords.RealPrecision.value)
         s = cppast.Serializer()

--- a/pykokkos/core/translators/functor.py
+++ b/pykokkos/core/translators/functor.py
@@ -17,7 +17,7 @@ def get_view_type(view: cppast.ClassType) -> str:
     """
 
     space: str = get_view_memory_space(view, "functor")
-    layout: str = f"ExecutionSpace::array_layout"
+    layout: str = f"typename ExecSpace::array_layout"
     view_type: str = cpp_view_type(view, space=space, layout=layout)
 
     return view_type
@@ -246,7 +246,7 @@ def generate_functor(
     struct = cppast.RecordDecl(cppast.ClassType(name), decls)
     struct.is_definition = True
 
-    struct.add_template_param("ExecutionSpace")
+    struct.add_template_param("ExecSpace")
     if members.has_real:
         struct.add_template_param(Keywords.RealPrecision.value)
         s = cppast.Serializer()

--- a/pykokkos/core/translators/functor.py
+++ b/pykokkos/core/translators/functor.py
@@ -147,6 +147,48 @@ def generate_constructor(
 
     return cppast.ConstructorDecl("", name, params, body)
 
+def generate_constructor_without_rand(
+    name: str,
+    fields: Dict[cppast.DeclRefExpr, cppast.PrimitiveType],
+    views: Dict[cppast.DeclRefExpr, cppast.ClassType]
+) -> cppast.ConstructorDecl:
+    """
+    Generate the functor constructor
+
+    :param name: the functor class name
+    :param fields: a dict mapping from field name to type
+    :param views: a dict mapping from view name to type
+    :param random_pool: a tuple of the pool name and type
+    :param has_rand_call: whether the function contains a call to pk.rand()
+    :returns: the cppast representation of the constructor
+    """
+
+    params: List[cppast.ParmVarDecl] = []
+    assignments: List[cppast.AssignOperator] = []
+
+    for n, t in fields.items():
+        params.append(cppast.ParmVarDecl(t, n))
+
+    for n, t in views.items():
+        # skip subviews
+        if t is None:
+            continue
+        view_type: str = get_view_type(t)
+        params.append(cppast.ParmVarDecl(view_type, n))
+
+    # Kokkos fails to compile a functor if there are no parameters in its constructor
+    if len(params) == 0:
+        decl = cppast.DeclRefExpr("pk_field")
+        type = cppast.PrimitiveType(cppast.BuiltinType.INT)
+        params.append(cppast.ParmVarDecl(type, decl))
+
+    assignments.extend(generate_assignments(fields))
+    # skip subviews
+    assignments.extend(generate_assignments({v: views[v] for v in views if views[v]}))
+
+    body = cppast.CompoundStmt(assignments)
+
+    return cppast.ConstructorDecl("", name, params, body)
 
 def generate_functor(
     name: str,
@@ -194,6 +236,7 @@ def generate_functor(
         decls.append(cppast.DeclStmt(cppast.FieldDecl(f"Kokkos::{pool_type}<>", pool_name)))
 
     decls.append(generate_constructor(name, fields, views, random_pool, has_rand_call))
+    decls.append(generate_constructor_without_rand(name, fields, views))
     for _, s in workunits.values():
         decls.append(s)
 

--- a/pykokkos/core/translators/functor_cast.py
+++ b/pykokkos/core/translators/functor_cast.py
@@ -15,11 +15,11 @@ def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision:
         real_str = visitors_util.view_dtypes[precision.name].value
 
     if members.has_real:
-        functor_type = f"{functor}<FunctorExecutionSpace,{real_str}>"
-        template_decl = f"template <class FunctorExecutionSpace,class ArgumentMemorySpace,class {real_str}>"
+        functor_type = f"{functor}<FunctorExecSpace,{real_str}>"
+        template_decl = f"template <class FunctorExecSpace,class ArgumentMemorySpace,class {real_str}>"
     else:
-        functor_type = f"{functor}<ExecutionSpace>"
-        template_decl = f"template <class ExecutionSpace,class ArgumentMemorySpace>"
+        functor_type = f"{functor}<ExecSpace>"
+        template_decl = f"template <class ExecSpace,class ArgumentMemorySpace>"
 
     cast_source = f"{template_decl} {functor_type} {functor}_from_pyObject(pybind11::object obj) {{"
 
@@ -35,7 +35,7 @@ def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision:
             continue
 
         space: str = "ArgumentMemorySpace"
-        layout: str = f"ExecutionSpace::array_layout"
+        layout: str = f"typename ExecSpace::array_layout"
         params[n.declname] = cpp_view_type(t, space=space, layout=layout,real=real_str)
 
     #cast arguments into cpp types
@@ -46,7 +46,7 @@ def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision:
             cast_source += f"{param_type} {name} = getattr(obj,\"{name}\").cast<{param_type}>();"
 
 
-    cast_source += generate_functor_instance(functor_type, members, False, "ExecutionSpace")
+    cast_source += generate_functor_instance(functor_type, members, False, "ExecSpace")
     cast_source += f"return {Keywords.Instance.value};"
     cast_source += "}"
 
@@ -60,11 +60,11 @@ def generate_cast_to_object(functor: str, members: PyKokkosMembers, precision: O
         real_str = visitors_util.view_dtypes[precision.name].value
 
     if members.has_real:
-        functor_type = f"{functor}<ExecutionSpace,{real_str}>"
-        template_decl = f"template <class ExecutionSpace,class ArgumentMemorySpace, class {real_str}>"
+        functor_type = f"{functor}<ExecSpace,{real_str}>"
+        template_decl = f"template <class ExecSpace,class ArgumentMemorySpace, class {real_str}>"
     else:
-        functor_type = f"{functor}<ExecutionSpace>"
-        template_decl = f"template <class ExecutionSpace,class ArgumentMemorySpace>"
+        functor_type = f"{functor}<ExecSpace>"
+        template_decl = f"template <class ExecSpace,class ArgumentMemorySpace>"
 
     cast_source = f"{template_decl} void {functor}_to_pyObject({functor_type}& functor, pybind11::object obj) {{"
 
@@ -80,7 +80,7 @@ def generate_cast_to_object(functor: str, members: PyKokkosMembers, precision: O
             continue
 
         space: str = "ArgumentMemorySpace"
-        layout: str = f"ExecutionSpace::array_layout"
+        layout: str = f"typename ExecSpace::array_layout"
         params[n.declname] = cpp_view_type(t, space=space, layout=layout,real=real_str)
 
     #cast members into cpp types

--- a/pykokkos/core/translators/functor_cast.py
+++ b/pykokkos/core/translators/functor_cast.py
@@ -55,7 +55,7 @@ def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision:
             cast_source += f"{param_type} {name} = getattr(obj,\"{name}\").cast<{param_type}>();"
 
 
-    cast_source += generate_functor_instance(functor_type, members, False, "ExecSpace")
+    cast_source += generate_functor_instance(functor_type, members, False, "ExecSpace", True)
     cast_source += f"return {Keywords.Instance.value};"
     cast_source += "}"
 

--- a/pykokkos/core/translators/functor_cast.py
+++ b/pykokkos/core/translators/functor_cast.py
@@ -1,0 +1,121 @@
+from typing import Dict, List, Optional, Tuple
+
+from pykokkos.core import cppast
+from pykokkos.core.keywords import Keywords
+from pykokkos.core.visitors import cpp_view_type, visitors_util
+from pykokkos.interface.data_types import DataType
+from .members import PyKokkosMembers
+from .bindings import generate_functor_instance,generate_copy_back,get_view_memory_space,generate_copy_back_from_dict
+
+
+
+def get_functor_name_and_type(functor: str, members: PyKokkosMembers, real: Optional[str]) -> Tuple[str,str]:
+
+    functor_type = functor
+    functor_name = functor
+    if members.has_real:
+        functor_type += f"<{real}>"
+        functor_name += f"_{real}"
+
+    return functor_type, functor_name
+
+def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision: Optional[DataType]) -> str:
+
+    real_str: Optional[str] = None
+    if precision is not None:
+        real_str = visitors_util.view_dtypes[precision.name].value
+
+    functor_type,functor_name = get_functor_name_and_type(functor,members,real_str)
+
+    cast_source = f"{functor_type} {functor_name}_from_pyObject(pybind11::object obj) {{"
+
+    # get functor members incl types
+    s = cppast.Serializer()
+    params: Dict[str, str] = {}
+    for n, t in members.fields.items():
+        params[n.declname] = s.serialize(t)
+
+    for n, t in members.views.items():
+        # skip subviews
+        if t is None:
+            continue
+
+        space: str = get_view_memory_space(t, "bindings")
+        layout: str = f"{Keywords.DefaultExecSpace.value}::array_layout"
+        params[n.declname] = cpp_view_type(t, space=space, layout=layout,real=real_str)
+
+    #cast arguments into cpp types
+    for name, param_type in params.items():
+        if param_type == "const std::string&":
+            cast_source += f"std::string {name} = getattr(obj,\"{name}\").cast<std::string>();"
+        else:
+            cast_source += f"{param_type} {name} = getattr(obj,\"{name}\").cast<{param_type}>();"
+
+    cast_source += generate_functor_instance(functor, members,False)
+    cast_source += f"return {Keywords.Instance.value};"
+    cast_source += "}"
+
+    return cast_source
+
+
+def generate_cast_to_object(functor: str, members: PyKokkosMembers, precision: Optional[DataType]) -> str:
+
+    real_str: Optional[str] = None
+    if precision is not None:
+        real_str = visitors_util.view_dtypes[precision.name].value
+
+    functor_type,functor_name = get_functor_name_and_type(functor,members,real_str)
+
+    cast_source = f"void {functor_name}_to_pyObject({functor_type}& functor, pybind11::object obj) {{"
+
+    # get functor members incl types
+    s = cppast.Serializer()
+    params: Dict[str, str] = {}
+    for n, t in members.fields.items():
+        params[n.declname] = s.serialize(t)
+
+    for n, t in members.views.items():
+        # skip subviews
+        if t is None:
+            continue
+
+        space: str = get_view_memory_space(t, "bindings")
+        layout: str = f"{Keywords.DefaultExecSpace.value}::array_layout"
+        params[n.declname] = cpp_view_type(t, space=space, layout=layout,real=real_str)
+
+    #cast members into cpp types
+    for name, param_type in params.items():
+        if param_type == "const std::string&":
+            cast_source += f"std::string {name} = pybind11::getattr(obj,\"{name}\").cast<std::string>();"
+        else:
+            cast_source += f"{param_type} {name} = pybind11::getattr(obj,\"{name}\").cast<{param_type}>();"
+
+
+    deep_copy_args: Dict[str, str] = {v.declname: f"functor.{v.declname}" for v in members.views \
+            if members.views[v] is not None}
+
+    cast_source += generate_copy_back_from_dict(members,deep_copy_args)
+
+    #assign members from cpp types
+    for name, param_type in params.items():
+        cast_source += f"pybind11::setattr(obj,\"{name}\",pybind11::cast({name}));"
+
+    cast_source += "}"
+
+    return cast_source
+
+def generate_cast(functor: str, members: PyKokkosMembers) -> List[str]:
+
+    source: List[str] = []
+    if members.has_real:
+        for d in DataType:
+            if d is DataType.real:
+                continue
+            source.append(generate_cast_from_object(functor,members,d))
+            source.append(generate_cast_to_object(functor,members,d))
+
+    else:
+        source.append(generate_cast_from_object(functor,members,None))
+        source.append(generate_cast_to_object(functor,members,None))
+
+    return source

--- a/pykokkos/core/translators/functor_cast.py
+++ b/pykokkos/core/translators/functor_cast.py
@@ -9,6 +9,15 @@ from .bindings import generate_functor_instance,generate_copy_back,get_view_memo
 
 
 def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision: Optional[DataType]) -> str:
+    """
+    Generates the source code of a c++ template for a "cast" operation from the python object to a c++ functor.
+    DOES NOT CHECK ANY FIELDS/TYPES/ETC
+
+    :param functor: the name of the functor without template args
+    :param members: an object containing the fields and views
+    :param precision: optional argument of type DataType for floatingpoint
+    :returns: the source code of the functor cast
+    """
 
     real_str: Optional[str] = None
     if precision is not None:
@@ -54,6 +63,15 @@ def generate_cast_from_object(functor: str, members: PyKokkosMembers, precision:
 
 
 def generate_cast_to_object(functor: str, members: PyKokkosMembers, precision: Optional[DataType]) -> str:
+    """
+    Generates the source code of a c++ template for a "cast" operation from the c++ functor to a python object.
+    DOES NOT CHECK ANY FIELDS/TYPES/ETC
+
+    :param functor: the name of the functor without template args
+    :param members: an object containing the fields and views
+    :param precision: optional argument of type DataType for floatingpoint
+    :returns: the source code of the functor cast
+    """
 
     real_str: Optional[str] = None
     if precision is not None:
@@ -105,6 +123,21 @@ def generate_cast_to_object(functor: str, members: PyKokkosMembers, precision: O
     return cast_source
 
 def generate_cast(functor: str, members: PyKokkosMembers) -> List[str]:
+    """
+    Generates the c++ templates for casting a functor to/from a python object. A pybind11 cast operator would need to know how to
+    construct the python object the functor wants to cast into. This is a problem as we do not know where the user defines 
+    the functor object and I did not want to import the main script into the c++ binding code just to know
+    how to construct the functor object in c++.
+    This is solved by passing in a python object when casting from the c++ object to the python object.
+    This leaves it to the user that calls the cast that the python object actually has all the members the cast assigns to ... 
+    the function has no guarantees or checks, as the interpreter should throw a runtime error if any of the assignments fails,
+    which is as good as it gets.
+    Both "casts" take care of the deep_copy and resize operations. This said, they are more like glorified copy operations
+
+    :param functor: the name of the functor without template arguments
+    :param members: object containing fields and views of the functor
+    :returns: the source code of the cast operators
+    """
 
     source: List[str] = []
     if members.has_real:

--- a/pykokkos/core/translators/static.py
+++ b/pykokkos/core/translators/static.py
@@ -15,6 +15,14 @@ from .functor import generate_functor
 from .members import PyKokkosMembers
 from .symbols_pass import SymbolsPass
 
+def generate_include_guard_start(symbol_name: str):
+    include_guard: str = f"#ifndef {symbol_name}\n"
+    include_guard += f"#define {symbol_name}\n"
+    return include_guard
+
+def generate_include_guard_end() -> str:
+    return "\n#endif"
+
 class StaticTranslator:
     """
     Translates a PyKokkos workload to C++ using static analysis only
@@ -68,12 +76,18 @@ class StaticTranslator:
 
         struct: cppast.RecordDecl = generate_functor(functor_name, self.pk_members, workunits, functions, has_rand_call)
 
+        cast: List[str] = [self.generate_header(), generate_include_guard_start(functor_name.upper()+"_CAST_"+"_HPP")]
+        cast.append(self.generate_cast_includes())
+        cast.append(generate_cast(functor_name,self.pk_members))
+        cast.append(generate_include_guard_end())
+
         bindings: List[str] = self.generate_bindings(entity, functor_name, source, workunits)
 
         s = cppast.Serializer()
-        functor: List[str] = [self.generate_header()]
+        functor: List[str] = [self.generate_header(), generate_include_guard_start(functor_name.upper()+"_HPP")]
         functor.extend([s.serialize(c) for c in classtypes])
         functor.append(s.serialize(struct))
+        functor.append(generate_include_guard_end())
 
         bindings.insert(0, self.generate_includes())
         bindings.insert(0, self.generate_header())

--- a/pykokkos/core/translators/static.py
+++ b/pykokkos/core/translators/static.py
@@ -78,7 +78,7 @@ class StaticTranslator:
 
         cast: List[str] = [self.generate_header(), generate_include_guard_start(functor_name.upper()+"_CAST_"+"_HPP")]
         cast.append(self.generate_cast_includes())
-        cast.append(generate_cast(functor_name,self.pk_members))
+        cast.extend(generate_cast(functor_name,self.pk_members))
         cast.append(generate_include_guard_end())
 
         bindings: List[str] = self.generate_bindings(entity, functor_name, source, workunits)

--- a/pykokkos/core/translators/static.py
+++ b/pykokkos/core/translators/static.py
@@ -12,6 +12,7 @@ from pykokkos.core.visitors import (
 
 from .bindings import bind_main, bind_workunits
 from .functor import generate_functor
+from .functor_cast import generate_cast
 from .members import PyKokkosMembers
 from .symbols_pass import SymbolsPass
 
@@ -28,7 +29,7 @@ class StaticTranslator:
     Translates a PyKokkos workload to C++ using static analysis only
     """
 
-    def __init__(self, module: str, functor: str, pk_members: PyKokkosMembers):
+    def __init__(self, module: str, functor: str,functor_cast: str, pk_members: PyKokkosMembers):
         """
         StaticTranslator Constructor
 
@@ -41,6 +42,7 @@ class StaticTranslator:
 
         self.module_file: str = module
         self.functor_file: str = functor
+        self.functor_cast: str = functor_cast
         self.pk_members: PyKokkosMembers = pk_members
 
     def translate(
@@ -92,7 +94,7 @@ class StaticTranslator:
         bindings.insert(0, self.generate_includes())
         bindings.insert(0, self.generate_header())
 
-        return functor, bindings
+        return functor, bindings, cast
 
     @staticmethod
     def add_parent_refs(classdef: ast.ClassDef) -> ast.ClassDef:
@@ -234,6 +236,28 @@ class StaticTranslator:
     def generate_includes(self) -> str:
         """
         Generate the list of include statements
+
+        :returns: the includes as a string
+        """
+
+        headers: List[str] = [
+            "pybind11/pybind11.h",
+            "Kokkos_Core.hpp",
+            "Kokkos_Random.hpp",
+            "Kokkos_Sort.hpp",
+            "fstream",
+            "iostream",
+            "cmath",
+            self.functor_file,
+            self.functor_cast
+        ]
+        headers = [f"#include <{h}>\n" for h in headers]
+
+        return "".join(headers)
+
+    def generate_cast_includes(self) -> str:
+        """
+        Generate the list of include statements for the cast header file
 
         :returns: the includes as a string
         """


### PR DESCRIPTION
This pr proposes custom "cast" functions to convert from a python object of the functor into the corresponding c++ functor. This allows other bindings that bind c++ libs that use kokkos to use pykokkos-generated functors in their bindings.

Why is it not a conventional "cast" operator but a free function?
A pybind11 cast operator would need to know how to construct the python object the functor wants to cast into. This is a problem as we do not know where the user defines the functor object and I did not want to import the main script into the c++ binding code just to know how to construct the functor object in c++.
This is solved by passing in a python object when casting from the c++ object to the python object. This leaves it to the user that calls the cast that the python object actually has all the members the cast assigns to ... the function has no guarantees or checks, as the interpreter should throw a runtime error if any of the assignments fails, which is as good as it gets. Both "casts" take care of the deep_copy and resize operations. This said, they are more like glorified copy operations

For this the following things were implemented:

- `functor_cast.py` script that generates the "cast" functions
- binding for the "cast" functions
- `compiler.py` and `cpp_setup.py` deal with the new file
- `translator.py` and `bindings.py` were refactored where necessary to avoid code repetition (this is just a proposal)
- Include guards for the functor.hpp and functor_cast.hpp file
- constructor for the c++ functor that does not get the rand stuff ... as we basically do an assignment which should not need it