### PR TITLE
Translator: add view hook template argument to view type for Kokkos 3.7

### DIFF
--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -1,4 +1,5 @@
 import ast
+import os
 import re
 import sys
 from typing import Dict, List, Optional, Set, Union
@@ -336,6 +337,8 @@ def cpp_view_type(
         params_ordered.append(params["layout"])
     if "space" in params:
         params_ordered.append(params["space"])
+    if "PK_NO_VIEW_HOOKS" not in os.environ:
+        params_ordered.append("Kokkos::Experimental::DefaultViewHooks")
     if "trait" in params:
         params_ordered.append(params["trait"])
 

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -4,6 +4,7 @@ import re
 import sys
 from typing import Dict, List, Optional, Set, Union
 
+from pykokkos import kokkos_manager as km
 from pykokkos.core import cppast
 from pykokkos.core.keywords import Keywords
 from pykokkos.interface import Layout, Trait
@@ -337,7 +338,7 @@ def cpp_view_type(
         params_ordered.append(params["layout"])
     if "space" in params:
         params_ordered.append(params["space"])
-    if "PK_NO_VIEW_HOOKS" not in os.environ:
+    if km.get_kokkos_version() >= 3.7:
         params_ordered.append("Kokkos::Experimental::DefaultViewHooks")
     if "trait" in params:
         params_ordered.append(params["trait"])

--- a/pykokkos/kokkos_manager/__init__.py
+++ b/pykokkos/kokkos_manager/__init__.py
@@ -7,6 +7,7 @@ from pykokkos.interface.execution_space import ExecutionSpace
 from pykokkos.interface.data_types import DataTypeClass, double
 
 CONSTANTS: Dict[str, Any] = {
+    "KOKKOS_VERSION": 3.7, # default to 3.7
     "EXECUTION_SPACE": ExecutionSpace.OpenMP,
     "REAL_DTYPE": double,
     "IS_INITIALIZED": False,
@@ -17,6 +18,13 @@ CONSTANTS: Dict[str, Any] = {
     "KOKKOS_GPU_MODULE_LIST": [],
     "DEVICE_ID": 0
 }
+
+def get_kokkos_version() -> float:
+    """
+    Get the version of the installed Kokkos library
+    """
+
+    return CONSTANTS["KOKKOS_VERSION"]
 
 def get_default_space() -> ExecutionSpace:
     """
@@ -178,6 +186,13 @@ def get_num_gpus() -> bool:
     """
 
     return CONSTANTS["NUM_GPUS"]
+
+pk_kokkos_version: str = os.getenv("PK_KOKKOS_INTERFACE")
+if pk_kokkos_version is not None:
+    try:
+        CONSTANTS["KOKKOS_VERSION"] = float(pk_kokkos_version)
+    except ValueError:
+        print(f"WARNING: PK_KOKKOS_INTERFACE value '{pk_kokkos_version}' is invalid; reverting to {get_kokkos_version()}")
 
 try:
     # Import multiple kokkos libs to support multiple devices per


### PR DESCRIPTION
The `PK_NO_VIEW_HOOKS` environment variable can be set if an older Kokkos version is used