### PR TITLE
Allow users to use pykokkos to compile their own modules from source

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -45,6 +45,9 @@ ignore_errors = True
 [mypy-pykokkos.interface.parallel_dispatch]
 ignore_errors = True
 
+[mypy-pykokkos.interface.ext_module]
+ignore_errors = True
+
 [mypy-pykokkos.interface.atomic.atomic_fetch_op]
 ignore_errors = True
 

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -200,10 +200,10 @@ class Compiler:
 
     def compile_raw_source(
         self,
-        main: Path,
+        output_dir: Path,
         source: List[str],
         filename: str,
-        module_setup: ModuleSetup,
+        module_file: str,
         space: ExecutionSpace,
         force_uvm: bool
         ) -> None:
@@ -218,9 +218,8 @@ class Compiler:
         :param members: the PyKokkos related members of the entity
         """
 
-        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files)
-        output_dir: Path = module_setup.get_output_dir(main, module_setup.metadata, space)
-        t_start: float = time.perf_counter()
+        cpp_setup = CppSetup(module_file, [])
+        c_start: float = time.perf_counter()
         cpp_setup.compile_raw_source(output_dir, source, filename, space, force_uvm, self.get_compiler())
         c_end: float = time.perf_counter() - c_start
         self.logger.info(f"compilation {c_end}")

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -198,6 +198,33 @@ class Compiler:
         c_end: float = time.perf_counter() - c_start
         self.logger.info(f"compilation {c_end}")
 
+    def compile_raw_source(
+        self,
+        main: Path,
+        source: List[str],
+        filename: str,
+        module_setup: ModuleSetup,
+        space: ExecutionSpace,
+        force_uvm: bool
+        ) -> None:
+        """
+        Compile the entity
+
+        :param main: the path to the main file in the current PyKokkos application
+        :param source: cpp source of module
+        :param filename: name of the file to store the source in
+        :param space: the execution space to compile for
+        :param force_uvm: whether CudaUVMSpace is enabled
+        :param members: the PyKokkos related members of the entity
+        """
+
+        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files)
+        output_dir: Path = module_setup.get_output_dir(main, module_setup.metadata, space)
+        t_start: float = time.perf_counter()
+        cpp_setup.compile_raw_source(output_dir, source, filename, space, force_uvm, self.get_compiler())
+        c_end: float = time.perf_counter() - c_start
+        self.logger.info(f"compilation {c_end}")
+
     def get_compiler(self) -> str:
         """
         Get the compiler to use based on the machine name

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -181,7 +181,7 @@ class Compiler:
         if module_setup.is_compiled():
             return
 
-        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files, self.functor_file,self.functor_cast_file, self.bindings_file)
+        cpp_setup = CppSetup(module_setup.module_file, module_setup.gpu_module_files)
         translator = StaticTranslator(module_setup.name, self.functor_file,self.functor_cast_file, members)
 
         t_start: float = time.perf_counter()
@@ -194,7 +194,7 @@ class Compiler:
 
         output_dir: Path = module_setup.get_output_dir(main, module_setup.metadata, space)
         c_start: float = time.perf_counter()
-        cpp_setup.compile(output_dir, functor, cast, bindings, space, force_uvm, self.get_compiler())
+        cpp_setup.compile(output_dir, functor, self.functor_file, cast, self.functor_cast_file, bindings, self.bindings_file, space, force_uvm, self.get_compiler())
         c_end: float = time.perf_counter() - c_start
         self.logger.info(f"compilation {c_end}")
 

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -57,7 +57,7 @@ class CppSetup:
         """
 
         self.initialize_directory(output_dir)
-        self.write_source(output_dir, source, filename)
+        self.write_raw_source(output_dir, source, filename)
         self.copy_script(output_dir)
         self.invoke_script(output_dir, space, enable_uvm, compiler)
 

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -126,9 +126,9 @@ class CppSetup:
         :param bindings_filename: the generated bindings_filename
         """
 
-        write_raw_source(self,output_dir.parent,functor,functor_filename)
-        write_raw_source(self,output_dir.parent,functor_cast,functor_cast_filename)
-        write_raw_source(self,output_dir,bindings,bindings_filename)
+        self.write_raw_source(output_dir.parent,functor,functor_filename)
+        self.write_raw_source(output_dir.parent,functor_cast,functor_cast_filename)
+        self.write_raw_source(output_dir,bindings,bindings_filename)
 
 
     def write_raw_source(self, output_dir: Path, source: List[str], filename: str) -> None:

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -18,7 +18,7 @@ class CppSetup:
     Creates the directory to hold the translation and invokes the compiler
     """
 
-    def __init__(self, module_file: str, gpu_module_files: List[str], functor: str,functor_cast: str, bindings: str):
+    def __init__(self, module_file: str, gpu_module_files: List[str]):
         """
         CppSetup constructor
 
@@ -30,9 +30,6 @@ class CppSetup:
 
         self.module_file: str = module_file
         self.gpu_module_files: List[str] = gpu_module_files
-        self.functor_file: str = functor
-        self.functor_cast_file: str = functor_cast
-        self.bindings_file: str = bindings
 
         self.script: str = "compile.sh"
         self.script_path: Path = Path(__file__).resolve().parent / self.script
@@ -70,8 +67,11 @@ class CppSetup:
         self,
         output_dir: Path,
         functor: List[str],
+        functor_filename: str,
         functor_cast: List[str],
+        functor_cast_filename: str,
         bindings: List[str],
+        bindings_filename: str,
         space: ExecutionSpace,
         enable_uvm: bool,
         compiler: str
@@ -81,13 +81,17 @@ class CppSetup:
 
         :param output_dir: the base directory
         :param functor: the translated C++ functor
+        :param functor_filename: the generated C++ functor filename
+        :param functor_cast: the generated C++ functor_cast
+        :param functor_cast_filename: the generated C++ functor_cast filename
         :param bindings: the generated bindings
+        :param bindings_filename: the generated bindings_filename
         :param space: the execution space to compile for
         :param enable_uvm: whether to enable CudaUVMSpace
         """
 
         self.initialize_directory(output_dir)
-        self.write_source(output_dir, functor, functor_cast, bindings)
+        self.write_source(output_dir, functor,functor_filename, functor_cast, functor_cast_filename, bindings, bindings_filename)
         self.copy_script(output_dir)
         self.invoke_script(output_dir, space, enable_uvm, compiler)
         if space in {ExecutionSpace.Cuda, ExecutionSpace.HIP} and km.is_multi_gpu_enabled():
@@ -111,22 +115,22 @@ class CppSetup:
         except FileExistsError:
             pass
 
-    def write_source(self, output_dir: Path, functor: List[str], functor_cast: List[str], bindings: List[str]) -> None:
+    def write_source(self, output_dir: Path, functor: List[str], functor_filename: str ,functor_cast: List[str], functor_cast_filename: str, bindings: List[str],bindings_filename: str) -> None:
         """
         Writes the generated C++ source code to a file
 
         :param output_dir: the base directory
         :param functor: the generated C++ functor
+        :param functor_filename: the generated C++ functor filename
+        :param functor_cast: the generated C++ functor_cast
+        :param functor_cast_filename: the generated C++ functor_cast filename
         :param bindings: the generated bindings
+        :param bindings_filename: the generated bindings_filename
         """
 
-        functor_path: Path = output_dir.parent / self.functor_file
-        functor_cast_path: Path = output_dir.parent / self.functor_cast_file
-        bindings_path: Path = output_dir / self.bindings_file
-
-        write_raw_source(self,output_dir.parent,functor,self.functor_file)
-        write_raw_source(self,output_dir.parent,functor_cast,self.functor_cast_file)
-        write_raw_source(self,output_dir,bindings,self.bindings_file)
+        write_raw_source(self,output_dir.parent,functor,functor_filename)
+        write_raw_source(self,output_dir.parent,functor_cast,functor_cast_filename)
+        write_raw_source(self,output_dir,bindings,bindings_filename)
 
 
     def write_raw_source(self, output_dir: Path, source: List[str], filename: str) -> None:

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -24,8 +24,6 @@ class CppSetup:
 
         :param module: the name of the file containing the compiled Python module
         :param gpu_module_files: the list of names of files containing for each gpu module
-        :param functor: the name of the generated functor file
-        :param bindings: the name of the generated bindings file
         """
 
         self.module_file: str = module_file

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -53,6 +53,8 @@ from .views import (
     asarray, result_type,
 )
 
+from .ext_module import compile_into_module
+
 
 def fence():
     pass

--- a/pykokkos/interface/ext_module.py
+++ b/pykokkos/interface/ext_module.py
@@ -1,5 +1,7 @@
 from pykokkos.runtime import runtime_singleton
 from .execution_space import ExecutionSpace
+from pathlib import Path
+from typing import List
 
 def compile_into_module(path: Path, source: List[str], module_name: str, executionSpace: ExecutionSpace = ExecutionSpace.Default):
     """

--- a/pykokkos/interface/ext_module.py
+++ b/pykokkos/interface/ext_module.py
@@ -1,7 +1,7 @@
 from pykokkos.runtime import runtime_singleton
 from .execution_space import ExecutionSpace
 
-def compile_into_module(path: str, source: str, module_name: str, executionSpace: ExecutionSpace = ExecutionSpace.Default):
+def compile_into_module(path: Path, source: List[str], module_name: str, executionSpace: ExecutionSpace = ExecutionSpace.Default):
     """
     Takes a c++ pybind11 source as a string and compiles it into a python module. The resulting python module is returned upon success
 

--- a/pykokkos/interface/ext_module.py
+++ b/pykokkos/interface/ext_module.py
@@ -1,0 +1,15 @@
+from pykokkos.runtime import runtime_singleton
+from .execution_space import ExecutionSpace
+
+def compile_into_module(path: str, source: str, module_name: str, executionSpace: ExecutionSpace = ExecutionSpace.Default):
+    """
+    Takes a c++ pybind11 source as a string and compiles it into a python module. The resulting python module is returned upon success
+
+    param path: Path to write the shared object produced in the compilation to
+    param source: c++ source of the module to be compiled with pybind11
+    param module_name: name of the module in python
+    param executionSpace: Executionspace which the module is compiled for
+
+    return: The compiled python module
+    """
+    return runtime_singleton.runtime.compile_into_module(path,source,module_name,executionSpace)

--- a/tests/test_ext_module.py
+++ b/tests/test_ext_module.py
@@ -17,7 +17,7 @@ class TestExternalModule(unittest.TestCase):
         self.source.append(f"m.attr(\"__name__\") = \"{self.module_name}\";")
         self.source.append("m.def(\"get_five\",[](){return 5;});")
         self.source.append("}") 
-        self.ext_module = pk.runtime_singleton.runtime.compile_into_module(self.path,self.source,self.module_name,pk.ExecutionSpace.Default)
+        self.ext_module = pk.compile_into_module(self.path,self.source,self.module_name)
 
     def test_call(self):
         self.assertEqual(5, self.ext_module.get_five())

--- a/tests/test_ext_module.py
+++ b/tests/test_ext_module.py
@@ -1,5 +1,6 @@
 import unittest
 
+from pathlib import Path
 import pykokkos as pk
 
 
@@ -11,14 +12,12 @@ class TestExternalModule(unittest.TestCase):
         self.module_name = "test_ext_module"
         self.source: List[str] = []
 
-        source.append("#include <pybind11/pybind11.h>\n")
-        source.append(f"PYBIND11_MODULE({module_name},m){")
-        source.append(f"m.attr(\"__name__\") = \"{module_name}\";")
-        source.append("m.def(\"get_five\",[](){return 5;});")
-        source.append("}") 
-
-    def test_compile(self):
-        self.ext_module = pk.runtime_singleton.runtime.compile_into_module(path,source,module_name,pk.ExecutionSpace.Default)
+        self.source.append("#include <pybind11/pybind11.h>\n")
+        self.source.append(f"PYBIND11_MODULE({self.module_name},m){{")
+        self.source.append(f"m.attr(\"__name__\") = \"{self.module_name}\";")
+        self.source.append("m.def(\"get_five\",[](){return 5;});")
+        self.source.append("}") 
+        self.ext_module = pk.runtime_singleton.runtime.compile_into_module(self.path,self.source,self.module_name,pk.ExecutionSpace.Default)
 
     def test_call(self):
         self.assertEqual(5, self.ext_module.get_five())

--- a/tests/test_ext_module.py
+++ b/tests/test_ext_module.py
@@ -1,0 +1,27 @@
+import unittest
+
+import pykokkos as pk
+
+
+# Tests if pk is able to compile an external module
+
+class TestExternalModule(unittest.TestCase):
+    def setUp(self):
+        self.path: Path = Path('./')
+        self.module_name = "test_ext_module"
+        self.source: List[str] = []
+
+        source.append("#include <pybind11/pybind11.h>\n")
+        source.append(f"PYBIND11_MODULE({module_name},m){")
+        source.append(f"m.attr(\"__name__\") = \"{module_name}\";")
+        source.append("m.def(\"get_five\",[](){return 5;});")
+        source.append("}") 
+
+    def test_compile(self):
+        self.ext_module = pk.runtime_singleton.runtime.compile_into_module(path,source,module_name,pk.ExecutionSpace.Default)
+
+    def test_call(self):
+        self.assertEqual(5, self.ext_module.get_five())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
based on #107. Adds interface to `runtime` class to let users compile an external module by providing the source code.
The external module is compiled with the same compilation script as the rest of the pykokkos stuff to ensure, that there is no configuration mismatch.
The test shows the basic usage for a very simple external module.