### PR TITLE
BUG: logging normal default

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -41,7 +41,9 @@ class Compiler:
         self.bindings_file: str = "bindings.cpp"
         self.defaults_file: str = "defaults.json"
 
-        logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+        loglevel = os.environ.get("PK_LOG_LEVEL", "WARNING")
+        numeric_level = getattr(logging, loglevel.upper(), None)
+        logging.basicConfig(stream=sys.stdout, level=numeric_level)
         self.logger = logging.getLogger()
 
     def compile_sources(

--- a/runtests.py
+++ b/runtests.py
@@ -11,6 +11,7 @@ cwd = os.getcwd()
 shutil.rmtree(os.path.join(cwd, "pk_cpp"),
               ignore_errors=True)
 
+from tests import _logging_probe
 
 # try to support command line arguments to
 # runtests.py that mirror direct usage of

--- a/tests/_logging_probe.py
+++ b/tests/_logging_probe.py
@@ -1,0 +1,14 @@
+# see gh-125
+
+# this is a bit tricky to probe in pytest
+# because of the logging interception
+# machinery, so running this outside of
+# pytest for now
+
+import logging
+from numpy.testing import assert_equal
+
+# imposing a default below WARNING level on other packages
+# is probably bad
+import pykokkos
+assert_equal(logging.root.level, 30)


### PR DESCRIPTION
* Fixes #125

* to prevent changing the default logging level of other Python libraries globally when importing `pykokkos`, we set its default log level to the Python standard library default and use `PK_LOG_LEVEL` env variable if we really want to change it

* `pytest` intercepts log activity in a tricky way, so at least for now the regression test I've added is a bit more creative than I'd like, but it does fail before/pass after