### PR TITLE
MAINT: mypy empty body fix

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
+allow_empty_bodies = True
 plugins = numpy.typing.mypy_plugin
 
 # third party dependencies


### PR DESCRIPTION
* a recent `mypy` update is causing some errors for `pykokkos` functions defined with return values but no function bodies, like this:

```python
def team_size(self) -> int:
    pass
```

* it may be that the author intended to mark these as say "abstract methods" that are to be implemented by inheriting classes, but I'm not sure, so for now I'm just relaxing the `mypy` configuration stringency so that we pass the static analysis again