### PR TITLE
MAINT, CI: use API tests 2022.09.30

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -39,8 +39,7 @@ jobs:
           cd /tmp
           git clone https://github.com/data-apis/array-api-tests.git
           cd array-api-tests
-          # see gh-63 for the commit pin
-          git checkout 4d9d7b4b73c
+          git checkout 2022.09.30
           git submodule update --init
           pip install -r requirements.txt
           export ARRAY_API_TESTS_MODULE=pykokkos


### PR DESCRIPTION
* use a tagged release of the array API conformance test suite to follow up on: https://github.com/kokkos/pykokkos/issues/63#issuecomment-1228726381

* this seems safe when I test locally at least--we'll see if the CI agrees

* this splits off the similar change from gh-124, to simplify that PR a little