### PR TITLE
ENH: ufunc dispatcher/concision

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -104,3 +104,6 @@ ignore_missing_imports = True
 
 [mypy-pykokkos.lib.manipulate]
 ignore_errors = True
+
+[mypy-pykokkos.lib.ufunc_workunits]
+ignore_errors = True

--- a/pre_compile_tools/pre_compile_ufuncs.py
+++ b/pre_compile_tools/pre_compile_ufuncs.py
@@ -27,13 +27,13 @@ def main():
     # level kernels/workunits directly
     filtered_function_list = []
     for f in function_list:
-        if not "impl" in f[0]:
+        if not "impl" in f[0] and not "dispatcher" in f[0]:
             filtered_function_list.append(f)
     # TODO: expand types and view dimensions for
     # ufunc pre-compilation as the support
     # grows more broadly for more dims and types in ufuncs
-    for dtype in [pk.double,
-                  pk.float,
+    for dtype in [pk.float64,
+                  pk.float32,
                   pk.int8,
                   pk.int16,
                   pk.int32,
@@ -53,12 +53,12 @@ def main():
                 # as unary if that fails
                 try:
                     func_obj(v, v)
-                except NotImplementedError:
+                except (NotImplementedError, KeyError):
                     pass
                 except TypeError:
                     try:
                         func_obj(v)
-                    except (NotImplementedError, RuntimeError):
+                    except (NotImplementedError, RuntimeError, KeyError):
                         pass
                 except RuntimeError:
                     # some cases like matmul have stricter

--- a/pykokkos/lib/ufunc_workunits.py
+++ b/pykokkos/lib/ufunc_workunits.py
@@ -1,0 +1,338 @@
+import pykokkos as pk
+
+
+@pk.workunit
+def isfinite_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_double(tid: int, view: pk.View2D[pk.double], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_float(tid: int, view: pk.View2D[pk.float], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_uint8(tid: int, view: pk.View1D[pk.uint8], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_uint8(tid: int, view: pk.View2D[pk.uint8], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_int8(tid: int, view: pk.View1D[pk.int8], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_int8(tid: int, view: pk.View2D[pk.int8], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_int16(tid: int, view: pk.View1D[pk.int16], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_int16(tid: int, view: pk.View2D[pk.int16], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_uint16(tid: int, view: pk.View1D[pk.uint16], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_uint16(tid: int, view: pk.View2D[pk.uint16], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_int32(tid: int, view: pk.View1D[pk.int32], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_int32(tid: int, view: pk.View2D[pk.int32], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_uint32(tid: int, view: pk.View1D[pk.uint32], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_uint32(tid: int, view: pk.View2D[pk.uint32], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_int64(tid: int, view: pk.View1D[pk.int64], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_int64(tid: int, view: pk.View2D[pk.int64], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isfinite_impl_1d_uint64(tid: int, view: pk.View1D[pk.uint64], out: pk.View1D[pk.uint8]):
+    out[tid] = isfinite(view[tid])
+
+
+@pk.workunit
+def isfinite_impl_2d_uint64(tid: int, view: pk.View2D[pk.uint64], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isfinite(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def equal_impl_1d_double(tid: int,
+                         view1: pk.View1D[pk.double],
+                         view2: pk.View1D[pk.double],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint8]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_uint16(tid: int,
+                         view1: pk.View1D[pk.uint16],
+                         view2: pk.View1D[pk.uint16],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint8]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int16(tid: int,
+                         view1: pk.View1D[pk.int16],
+                         view2: pk.View1D[pk.int16],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint8]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int32(tid: int,
+                         view1: pk.View1D[pk.int32],
+                         view2: pk.View1D[pk.int32],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint8]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def equal_impl_1d_int64(tid: int,
+                         view1: pk.View1D[pk.int64],
+                         view2: pk.View1D[pk.int64],
+                         view2_size: int,
+                         view_result: pk.View1D[pk.uint8]):
+    view2_idx: int = 0
+    if view2_size == 1:
+        view2_idx = 0
+    else:
+        view2_idx = tid
+    if view1[tid] == view2[view2_idx]:
+        view_result[tid] = 1
+    else:
+        view_result[tid] = 0
+
+
+@pk.workunit
+def isinf_impl_1d_double(tid: int, view: pk.View1D[pk.double], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_float(tid: int, view: pk.View1D[pk.float], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_int8(tid: int, view: pk.View1D[pk.int8], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_int64(tid: int, view: pk.View1D[pk.int64], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_int32(tid: int, view: pk.View1D[pk.int32], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_uint8(tid: int, view: pk.View1D[pk.uint8], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_2d_uint8(tid: int, view: pk.View2D[pk.uint8], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_float(tid: int, view: pk.View2D[pk.float], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_double(tid: int, view: pk.View2D[pk.double], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_int8(tid: int, view: pk.View2D[pk.int8], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_int64(tid: int, view: pk.View2D[pk.int64], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_1d_uint16(tid: int, view: pk.View1D[pk.uint16], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_1d_int16(tid: int, view: pk.View1D[pk.int16], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_2d_int16(tid: int, view: pk.View2D[pk.int16], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_int32(tid: int, view: pk.View2D[pk.int32], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_2d_uint16(tid: int, view: pk.View2D[pk.uint16], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_1d_uint32(tid: int, view: pk.View1D[pk.uint32], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_2d_uint32(tid: int, view: pk.View2D[pk.uint32], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def isinf_impl_1d_uint64(tid: int, view: pk.View1D[pk.uint64], out: pk.View1D[pk.uint8]):
+    out[tid] = isinf(view[tid])
+
+
+@pk.workunit
+def isinf_impl_2d_uint64(tid: int, view: pk.View2D[pk.uint64], out: pk.View2D[pk.uint8]):
+    for i in range(view.extent(1)): # type: ignore
+        out[tid][i] = isinf(view[tid][i]) # type: ignore
+
+
+@pk.workunit
+def matmul_impl_1d_double(tid: int, acc: pk.Acc[pk.double], viewA: pk.View1D[pk.double], viewB: pk.View2D[pk.double]):
+    acc += viewA[tid] * viewB[0][tid]
+
+
+@pk.workunit
+def matmul_impl_1d_float(tid: int, acc: pk.Acc[pk.float], viewA: pk.View1D[pk.float], viewB: pk.View2D[pk.float]):
+    acc += viewA[tid] * viewB[0][tid]
+
+
+@pk.workunit
+def reciprocal_impl_1d_double(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = 1 / view[tid] # type: ignore
+
+
+@pk.workunit
+def reciprocal_impl_1d_float(tid: int, view: pk.View1D[pk.float]):
+    view[tid] = 1 / view[tid] # type: ignore
+
+
+@pk.workunit
+def reciprocal_impl_2d_double(tid: int, view: pk.View2D[pk.double]):
+    for i in range(view.extent(1)): # type: ignore
+        view[tid][i] = 1 / view[tid][i] # type: ignore
+
+
+@pk.workunit
+def reciprocal_impl_2d_float(tid: int, view: pk.View2D[pk.float]):
+    for i in range(view.extent(1)): # type: ignore
+        view[tid][i] = 1 / view[tid][i] # type: ignore


### PR DESCRIPTION
Fixes #135

* use a ufunc workunit dispatcher to improve concision of the ufunc code for these ufuncs,
as an initial demonstration:
  - `isfinite()` (`parallel_for`)
  - `equal()` (`parallel_for`)
  - `isinf()` (`parallel_for`)
  - `matmul()` (`parallel_reduce`)
  - `reciprocal()` (`parallel_for`)

* the reduction in LOC is around: 250

* the changes do not guarantee identical behavior beyond the testsuite passing, so for example
error handling behavior may not be fully preserved

* our type system still needs a cleanup to make things more consistent per gh-80