### PR TITLE
Get use- and colorful output from `compile.sh`

### DIFF
--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -244,7 +244,8 @@ class CppSetup:
                               lib_suffix,           # The libkokkos* suffix identifying the gpu
                               str(compiler_path)]   # The path to the compiler to use
 
-        if True:
+        if sys.platform == "linux" or sys.platform == "linux2":
+            #on linux we can color the output otherwise this is not implemented
             command = [string if string != '' else "''" for string in command]
             command: Str = "script --log-io compile.out --return --command " + "\""+" ".join(command) + "\""
 
@@ -252,7 +253,7 @@ class CppSetup:
 
         if compile_result.returncode != 0:
             print(compile_result.stderr.decode("utf-8"))
-            print(f"C++ compilation in {output_dir} failed. For colored compiler output run 'cat {output_dir}/compile.out'")
+            print(f"C++ compilation in {output_dir} failed. For colored compiler output (on linux) run 'cat {output_dir}/compile.out'")
             sys.exit(1)
 
         patchelf: List[str] = ["patchelf",

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -328,10 +328,14 @@ class CppSetup:
     @staticmethod
     def is_compiled(output_dir: Path) -> bool:
         """
-        Check if an entity is compiled
+        Check if an entity is compiled. It does this via checking if any .so file exists.
 
         :param output_dir: the directory containing the compiled entity
-        :returns: true if compiled
+        :returns: true if any .so object exists
         """
+        so_files = output_dir.glob("*.so")
+        contains_so_files = False
+        for file in so_files:
+            contains_so_files = file.is_file()
 
-        return output_dir.is_dir()
+        return contains_so_files

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -245,7 +245,7 @@ class CppSetup:
                               str(compiler_path)]   # The path to the compiler to use
 
         if True:
-            command = [string if string != '' else "' '" for string in command]
+            command = [string if string != '' else "''" for string in command]
             command: Str = "script --log-io compile.out --return --command " + "\""+" ".join(command) + "\""
 
         compile_result = subprocess.run(command, cwd=output_dir, capture_output=True, check=False, shell=True)

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -243,11 +243,16 @@ class CppSetup:
                               compute_capability,   # Device compute capability
                               lib_suffix,           # The libkokkos* suffix identifying the gpu
                               str(compiler_path)]   # The path to the compiler to use
-        compile_result = subprocess.run(command, cwd=output_dir, capture_output=True, check=False)
+
+        if True:
+            command = [string if string != '' else "' '" for string in command]
+            command: Str = "script --log-io compile.out --return --command " + "\""+" ".join(command) + "\""
+
+        compile_result = subprocess.run(command, cwd=output_dir, capture_output=True, check=False, shell=True)
 
         if compile_result.returncode != 0:
             print(compile_result.stderr.decode("utf-8"))
-            print(f"C++ compilation in {output_dir} failed")
+            print(f"C++ compilation in {output_dir} failed. For colored compiler output run 'cat {output_dir}/compile.out'")
             sys.exit(1)
 
         patchelf: List[str] = ["patchelf",


### PR DESCRIPTION
This originated from a discussion with @tylerjereddy on slack.
In short: We would like to have a better error handling if stuff does not compile. Ideally we want to even have warnings before the compilation stage fails but this is a goal for the future. As a starter I like to propose that we capture the output of the compilation script as good as we can (this includes warnings and errors in the right order and colors if the compiler does a colored and highlighted output).

Apparently scripts detect if the output is piped into a file or a shell and restrict the coloring/hinting if it goes to a file. The linux standard program `script` can run a command and force the output to be logged as if it were in a shell thus capturing the coloring and other highlights.

If I artificially introduce an error in the generated cpp file I get something like this when running a pykokkos script that compiles the broken cpp file:
```
Total size S = 262144 N = 256 M = 1024 E = 1024
Total size S = 262144 N = 256 M = 1024

C++ compilation in pk_cpp/pykokkos/examples/kokkos-tutorials/functor/04/04_Workload/Cuda failed. For colored compiler output run 'cat pk_cpp/pykokkos/examples/kokkos-tutorials/functor/04/04_Workload/Cuda/compile.out'
```

When pasting the newly written `.out` file with the suggested command I get this rendered in my terminal:
<img width="589" alt="Screenshot 2023-02-09 at 17 45 07" src="https://user-images.githubusercontent.com/104908666/217880989-78cdedc7-a3c9-4963-8861-af9b127330a9.png">

Which is the same as I would get from directly running the compile line on the generated .cpp file