### PR TITLE
MAINT, CI: mypy bump

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==0.981 cmake pytest pybind11 scikit-build patchelf tqdm
+          python -m pip install --upgrade numpy mypy==1.0.1 cmake pytest pybind11 scikit-build patchelf tqdm
       - name: Install pykokkos-base
         run: |
           cd /tmp

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==0.981 cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy==1.0.1 cmake pytest pybind11 scikit-build patchelf
       - name: Install pykokkos-base
         run: |
           cd /tmp


### PR DESCRIPTION
* local testing suggests it should be safe to bump to the latest stable release of `mypy`, so let's see if CI agrees

* it can be ~40 % faster in the `1.0` series (https://mypy-lang.blogspot.com/2023/02/mypy-10-released.html), though I doubt this matters much for us