### PR TITLE
BUG: fix caching for user-defined functor vars

### DIFF
--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,0 +1,25 @@
+import pykokkos as pk
+
+
+@pk.functor
+class Workload_gh_173:
+    def __init__(self, s: int):
+        self.size: pk.int = s
+        self.result: pk.View1D[pk.int64] = pk.View([1], dtype= pk.int64)
+
+
+    @pk.workunit
+    def store_result(self, i: int):
+        self.result[i] = self.size
+
+
+def test_gh_173():
+    # this is a more tractable test case for gh-173
+    # since it provides a retrieved value rather than
+    # a printed value
+    w = Workload_gh_173(900)
+    pk.parallel_for(1, w.store_result)
+    assert w.result[0] == 900
+    w.size = 10
+    pk.parallel_for(1, w.store_result)
+    assert w.result[0] == 10


### PR DESCRIPTION
* Fixes #173

* add a regression test for gh-173 and fix the issue by invalidating the workunit cache when user-defined variables are used in a kernel

* this just builds on my previous skepticism that our cache is actually "safe"/useful as you can see
from the previous comments in the code in this area

* this fix may be more aggressive than needed, but since this fixes a bug it seems justified to me even if there is a broader performance implication, since the tests clearly are not in place to handle these cases