### PR TITLE
ENH: allow type double scratch

### DIFF
--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -195,6 +195,17 @@ def get_type(annotation: Union[ast.Attribute, ast.Name, ast.Subscript], pk_impor
 
             return cppast.ClassType(type_name)
 
+    if isinstance(annotation, ast.Index):
+        # ast.Index has been deprecated since Python 3.9;
+        # this module attempts to shim around it, but we're
+        # still getting issues in gh-181 with Python 3.8
+
+        # we should probably drop support for Python 3.8 soon anyway
+        # per NEP29, but for now we attempt to handle ast.Index
+
+        # should convert to ast.Name:
+        annotation = annotation.value
+
     if isinstance(annotation, ast.Name):
         type_name: str = annotation.id
 

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -15,7 +15,8 @@ def pretty_print(node):
 
 allowed_types: Dict[str, str] = {
     "int": "int",
-    "float": "double",
+    "float": "float",
+    "double": "double",
     "bool": "bool",
     "TeamMember": f"Kokkos::TeamPolicy<{Keywords.DefaultExecSpace.value}>::member_type",
 }

--- a/tests/test_AST_translator.py
+++ b/tests/test_AST_translator.py
@@ -306,5 +306,17 @@ class TestASTTranslator(unittest.TestCase):
         self.assertEqual(expected_result, result)
 
 
+@pk.workunit
+def scratch_with_double_float(team_member: pk.TeamMember):
+    scratch_mem_d: pk.ScratchView1D[double] = pk.ScratchView1D(team_member.team_scratch(0))
+    scratch_mem_f: pk.ScratchView1D[float] = pk.ScratchView1D(team_member.team_scratch(0))
+
+
+def test_gh_180():
+    pk.parallel_for("double_float_scratch",
+                    pk.TeamPolicy(league_size=2, team_size=2),
+                    scratch_with_double_float)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #180

* allow for scratch memory to be viewed as type `double`, including a regression test

* this is needed for shared memory usage in the DGEMM tiling algorithm (D = `double`)

* it turns out that `float` was aliased to `double`, which is incredibly confusing--I've adjusted such that `float` means `float` and `double` means `double`, which seems like the only sane design