### PR TITLE
Use right if-condition for view assignments in functor translation

### DIFF
--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -154,7 +154,7 @@ def generate_functor_instance(functor: str, members: PyKokkosMembers, with_rando
     for v, d_v in device_views.items():
         args.append(d_v)
 
-        if always_use_kokkos_copy:
+        if not always_use_kokkos_copy:
             view_type: cppast.ClassType = members.views[cppast.DeclRefExpr(v)]
             if get_view_memory_space(view_type, "bindings") == Keywords.ArgMemSpace.value:
                 mirror_views += f"auto {d_v} = Kokkos::create_mirror_view_and_copy({exec_space_instance}, {v});"


### PR DESCRIPTION
Fixes #187 ... Looks like I forgot a `not` for a condition when changing the bindings for the generated functor. 
The mistake was introduced in #107 