### PR TITLE
Append '_tag' to tags in generated cpp code

### DIFF
--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -288,7 +288,7 @@ def generate_call(operation: str, functor: str, members: PyKokkosMembers, tag: c
 
     args: List[str] = [Keywords.KernelName.value]
 
-    tag_name: str = tag.declname
+    tag_name: str = tag.declname+"_tag"
     if is_hierarchical:
         args.append(f"Kokkos::TeamPolicy<{Keywords.DefaultExecSpace.value},{functor}::{tag_name}>({Keywords.LeagueSize.value},Kokkos::AUTO,{Keywords.VectorLength.value})")
     else:

--- a/pykokkos/core/translators/functor.py
+++ b/pykokkos/core/translators/functor.py
@@ -215,7 +215,7 @@ def generate_functor(
 
     # Create the tags needed to call individual workunits. Tags in Kokkos are empty structs.
     for n in workunits:
-        tag = cppast.RecordDecl(cppast.ClassType(n.declname), [])
+        tag = cppast.RecordDecl(cppast.ClassType(n.declname+"_tag"), [])
         tag.is_definition = True
         decls.append(tag)
 

--- a/pykokkos/core/visitors/kokkosmain_visitor.py
+++ b/pykokkos/core/visitors/kokkosmain_visitor.py
@@ -434,7 +434,7 @@ class KokkosMainVisitor(PyKokkosVisitor):
         """
 
         policy_constructor = self.get_policy_constructor(policy)
-        policy_constructor.add_template_param(cppast.DeclRefExpr(f"{self.functor}::{work_unit}"))
+        policy_constructor.add_template_param(cppast.DeclRefExpr(f"{self.functor}::{work_unit}_tag"))
 
         return policy
 

--- a/pykokkos/core/visitors/workunit_visitor.py
+++ b/pykokkos/core/visitors/workunit_visitor.py
@@ -35,7 +35,7 @@ class WorkunitVisitor(PyKokkosVisitor):
             if operation is None:
                 self.error(node.args, "Incorrect types in workunit definition")
 
-            tag_type = cppast.ClassType(f"const {node.name}")
+            tag_type = cppast.ClassType(f"const {node.name}_tag")
             tag_type.is_reference = True
             tag = cppast.ParmVarDecl(tag_type, cppast.DeclRefExpr(""))
 

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -23,3 +23,23 @@ def test_gh_173():
     w.size = 10
     pk.parallel_for(1, w.store_result)
     assert w.result[0] == 10
+
+
+
+@pk.workunit
+def sin(tid: int, view: pk.View1D[pk.double]):
+    view[tid] = sin(view[tid])
+
+
+def test_gh_192_1():
+    #Regression Test to check if workunits can have the same name as functions called within
+    #this previously errored out in the compilation stage as we used tags with the name of the workunit.
+    #The error originated from the compiler using the tag's ctor call instead of the function that we wanted to use in the workunit 
+    v = pk.View([10], dtype=pk.float64)
+    pk.parallel_for(1, sin, view=v)
+
+def test_gh_192_2():
+    #the same has to hold if we manually specify a policy
+    v = pk.View([10], dtype=pk.float64)
+    policy = pk.RangePolicy(pk.ExecutionSpace.Default,0,1)
+    pk.parallel_for(policy,sin,view=v)


### PR DESCRIPTION
Fixes #192.
So far we used empty structs with the workunit name as tagname in the generated cpp code. This results in ambiguity if the workunit has the same name as the function it is calling. A prominent example is the `sin` that @tylerjereddy discovered in #192.

This PR renames the tags by adding `_tag` to the definition. This naming was chosen to increase readability on the cpp side while resolving the ambiguity. 