### PR TITLE
CI: run on main

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -3,10 +3,10 @@ name: Array API Testing
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
 
 jobs:
   test_array_api:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -3,10 +3,10 @@ name: Python Testing
 on:
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
 
 jobs:
   test_pykokkos:


### PR DESCRIPTION
* adjust our GHA CI configs to run on PRs against `main` given switch to development on `main` noted at:
https://github.com/kokkos/pykokkos/pull/198#issue-1704592469