### PR TITLE
Decorator generation + Polished type Inference

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -53,6 +53,7 @@ class Compiler:
         force_uvm: bool,
         updated_decorator: UpdatedDecorator,
         updated_types: Optional[UpdatedTypes] = None,
+        types_signature: Optional[str] = None
     ) -> Optional[PyKokkosMembers]:
         """
         Compile an entity object for a single execution space
@@ -67,7 +68,7 @@ class Compiler:
 
         metadata = module_setup.metadata
         parser = self.get_parser(metadata.path)
-        types_signature: str = get_types_sig(updated_types, updated_decorator)
+
         hash: str = self.members_hash(metadata.path, metadata.name, types_signature)
         entity: PyKokkosEntity = parser.get_entity(metadata.name)
 

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -60,6 +60,7 @@ class Compiler:
         :param entity_object: the module_setup object containing module info
         :param space: the execution space to compile for
         :param force_uvm: whether CudaUVMSpace is enabled
+        :param updated_decorator: Object for decorator specifiers
         :param updated_types: Object with with inferred types
         :returns: the PyKokkos members obtained during translation
         """

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -12,7 +12,7 @@ from pykokkos.interface import ExecutionSpace, UpdatedTypes, UpdatedDecorator, g
 import pykokkos.kokkos_manager as km
 from .cpp_setup import CppSetup
 from .module_setup import EntityMetadata, ModuleSetup
-import ast
+
 @dataclass
 class CompilationDefaults:
     """

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -8,7 +8,7 @@ import time
 from typing import Dict, List, Optional
 from pykokkos.core.parsers import Parser, PyKokkosEntity, PyKokkosStyles
 from pykokkos.core.translators import PyKokkosMembers, StaticTranslator
-from pykokkos.interface import ExecutionSpace, UpdatedTypes, UpdatedDecorator
+from pykokkos.interface import ExecutionSpace, UpdatedTypes, UpdatedDecorator, get_types_sig
 import pykokkos.kokkos_manager as km
 from .cpp_setup import CppSetup
 from .module_setup import EntityMetadata, ModuleSetup
@@ -66,7 +66,7 @@ class Compiler:
 
         metadata = module_setup.metadata
         parser = self.get_parser(metadata.path)
-        types_signature = None if updated_types is None else updated_types.types_signature
+        types_signature: str = get_types_sig(updated_types, updated_decorator)
         hash: str = self.members_hash(metadata.path, metadata.name, types_signature)
         entity: PyKokkosEntity = parser.get_entity(metadata.name)
 
@@ -94,7 +94,7 @@ class Compiler:
             entity.AST = parser.fix_types(entity, updated_types)
         if decorator_inferred:
             entity.AST = parser.fix_decorator(entity, updated_decorator)
-        print(ast.dump(entity.AST))
+
         if hash in self.members: # True if compiled with another execution space
             members = self.members[hash]
         else:

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -8,7 +8,7 @@ import time
 from typing import Dict, List, Optional
 from pykokkos.core.parsers import Parser, PyKokkosEntity, PyKokkosStyles
 from pykokkos.core.translators import PyKokkosMembers, StaticTranslator
-from pykokkos.interface import ExecutionSpace, UpdatedTypes, UpdatedDecorator, get_types_sig
+from pykokkos.interface import ExecutionSpace, UpdatedTypes, UpdatedDecorator
 import pykokkos.kokkos_manager as km
 from .cpp_setup import CppSetup
 from .module_setup import EntityMetadata, ModuleSetup

--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -82,6 +82,7 @@ class ModuleSetup:
         ModuleSetup constructor
 
         :param entity: the functor/workunit/workload
+        :param types_signature: hash/string to identify workunit signature against types
         """
 
         self.metadata: EntityMetadata
@@ -129,7 +130,7 @@ class ModuleSetup:
         :param main: the path to the main file in the current PyKokkos application
         :param metadata: the metadata of the entity being compiled
         :param space: the execution space to compile for
-        :param types_signature: optional identifier string for inferred types of parameters
+        :param types_signature: optional identifier/hash string for types of parameters
         :returns: the path to the output directory for a specific execution space
         """
 

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -293,7 +293,7 @@ class Parser:
         needs_reset: bool = self.check_self(entity_tree)
         if needs_reset:
             entity_tree = self.reset_entity_tree(entity_tree, updated_decorator)
-        assert len(entity_tree.decorator_list), f"Decorator cannot be missing for pykokkos workunit {node.name}"
+        assert len(entity_tree.decorator_list), f"Decorator cannot be missing for pykokkos workunit {entity_tree.name}"
 
         if not len(updated_decorator.inferred_decorator):
             # no change needed

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -310,7 +310,7 @@ class Parser:
         return entity_tree
 
 
-    def get_keyword_node(self, view_name: str, specifier_dict: Dict[str, str]) -> ast.keyword:
+    def get_keyword_node(self, view_name: str, specifiers: Dict[str, str]) -> ast.keyword:
         '''
         Make the ast.keyword node to be added to the decorator list
 
@@ -319,10 +319,10 @@ class Parser:
         :returns: corresponding ast.keyword node that can be added to decorator list 
         '''
 
-        skip_space: bool = False if specifier_dict['trait'] == "Unmanaged" else True
+        skip_space: bool = False if specifiers['trait'] == "Unmanaged" else True
         keywords_list: List[ast.keyword] = []
         attr_names = {'layout' : 'Layout', 'space' : 'MemorySpace', 'trait' : 'Trait'}
-        for specifier, value in specifier_dict.items():
+        for specifier, value in specifiers.items():
             if specifier == "space" and skip_space:
                 continue
             keywords_list.append(

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -288,6 +288,7 @@ class Parser:
         :param updated_decorator: Object with dict that maps view to its layout, space and trait
         :returns: decorator list 
         '''
+
         entity_tree = entity.AST
         needs_reset: bool = self.check_self(entity_tree)
         if needs_reset:

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -1,6 +1,5 @@
 import ast
 import inspect
-import copy
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable, Dict, List, Tuple, Union

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -318,7 +318,20 @@ class Parser:
         :param layout: pykokkos Layout as string
         :returns: corresponding ast.keyword node that can be added to decorator list 
         '''
-
+        keywords_list = []
+        attr_names = {'layout' : 'Layout', 'space' : 'MemorySpace', 'trait' : 'Trait'}
+        for specifier, value in specifier_dict.items():
+            keywords_list.append(
+                ast.keyword(
+                    arg=specifier, 
+                    value=ast.Attribute(
+                        value=ast.Attribute(
+                            value=ast.Name(id=self.pk_import, ctx=ast.Load()), 
+                            attr=attr_names[specifier], ctx=ast.Load()), 
+                        attr=value, ctx=ast.Load()
+                        )
+                )
+            )
         return ast.keyword(
             arg=view_name, 
             value=ast.Call(
@@ -327,35 +340,7 @@ class Parser:
                     attr='ViewTypeInfo', ctx=ast.Load()
                 ), 
                 args=[], 
-                keywords=[
-                    ast.keyword(
-                        arg='layout', 
-                        value=ast.Attribute(
-                            value=ast.Attribute(
-                                value=ast.Name(id=self.pk_import, ctx=ast.Load()), 
-                                attr='Layout', ctx=ast.Load()), 
-                            attr=specifier_dict['layout'], ctx=ast.Load()
-                            )
-                    ),
-                    ast.keyword(
-                        arg='space', 
-                        value=ast.Attribute(
-                            value=ast.Attribute(
-                                value=ast.Name(id=self.pk_import, ctx=ast.Load()), 
-                                attr='MemorySpace', ctx=ast.Load()), 
-                            attr=specifier_dict['space'], ctx=ast.Load()
-                            )
-                    ),
-                    ast.keyword(
-                        arg='trait', 
-                        value=ast.Attribute(
-                            value=ast.Attribute(
-                                value=ast.Name(id=self.pk_import, ctx=ast.Load()), 
-                                attr='Trait', ctx=ast.Load()), 
-                            attr=specifier_dict['trait'], ctx=ast.Load()
-                            )
-                    )
-                ]
+                keywords= keywords_list
             )
         )
 

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -318,9 +318,13 @@ class Parser:
         :param layout: pykokkos Layout as string
         :returns: corresponding ast.keyword node that can be added to decorator list 
         '''
-        keywords_list = []
+
+        skip_space: bool = False if specifier_dict['trait'] == "Unmanaged" else True
+        keywords_list: List[ast.keyword] = []
         attr_names = {'layout' : 'Layout', 'space' : 'MemorySpace', 'trait' : 'Trait'}
         for specifier, value in specifier_dict.items():
+            if specifier == "space" and skip_space:
+                continue
             keywords_list.append(
                 ast.keyword(
                     arg=specifier, 

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -311,7 +311,7 @@ class Parser:
         return entity_tree
 
 
-    def get_keyword_node(self, view_name: str, specifier_dict: dict[str, str]) -> ast.keyword:
+    def get_keyword_node(self, view_name: str, specifier_dict: Dict[str, str]) -> ast.keyword:
         '''
         Make the ast.keyword node to be added to the decorator list
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -59,6 +59,7 @@ class Runtime:
         space: ExecutionSpace,
         updated_decorator: UpdatedDecorator,
         updated_types: Optional[UpdatedTypes] = None,
+        types_signature: Optional[str] = None,
         ) -> Optional[PyKokkosMembers]:
         """
         precompile the workunit
@@ -69,15 +70,15 @@ class Runtime:
         :param space: the ExecutionSpace for which the bindings are generated
         :returns: the members the functor is containing
         """
-        types_signature: str = get_types_sig(updated_types, updated_decorator)
+
         module_setup: ModuleSetup = self.get_module_setup(workunit, space, types_signature)
         members: Optional[PyKokkosMembers] = self.compiler.compile_object(module_setup, 
                                                                           space, km.is_uvm_enabled(), 
                                                                           updated_decorator, 
-                                                                          updated_types)
+                                                                          updated_types, types_signature)
 
         return members
-
+    
     def compile_into_module(
         self,
         main: Path,

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -126,11 +126,11 @@ class Runtime:
                 raise RuntimeError("ERROR: operation cannot be None for Debug")
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)
 
-        members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types)
+        types_signature: str = get_types_sig(updated_types, updated_decorator)
+        members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature)
         if members is None:
             raise RuntimeError("ERROR: members cannot be none")
 
-        types_signature: str = get_types_sig(updated_types, updated_decorator)
         module_setup: ModuleSetup = self.get_module_setup(workunit, execution_space, types_signature)
         return self.execute(workunit, module_setup, members, execution_space, policy=policy, name=name, **kwargs)
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -126,7 +126,7 @@ class Runtime:
                 raise RuntimeError("ERROR: operation cannot be None for Debug")
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)
 
-        types_signature: str = get_types_sig(updated_types, updated_decorator)
+        types_signature: str = get_types_sig(updated_types, updated_decorator, execution_space)
         members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature)
         if members is None:
             raise RuntimeError("ERROR: members cannot be none")

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -64,6 +64,8 @@ class Runtime:
         precompile the workunit
 
         :param workunit: the workunit function object
+        :param updated_decorator: Object for decorator specifier
+        :param updated_types: Object with type inference information
         :param space: the ExecutionSpace for which the bindings are generated
         :returns: the members the functor is containing
         """
@@ -109,6 +111,7 @@ class Runtime:
         :param policy: the execution policy of the operation
         :param workunit: the workunit function object
         :param kwargs: the keyword arguments passed to the workunit
+        :param updated_decorator: Object with decorator specifier information
         :param updated_types: UpdatedTypes object with type inferrence information
         :param operation: the name of the operation "for", "reduce", or "scan"
         :param initial_value: the initial value of the accumulator
@@ -442,7 +445,7 @@ class Runtime:
 
         :param entity: the workload or workunit object
         :param space: the execution space
-        :updated_types: Object with information about inferred types (if any)
+        :types_signature: Hash/identifer string for workunit module against data types
         :returns: the ModuleSetup object
         """
 
@@ -472,7 +475,7 @@ class Runtime:
 
         :param entity: the workload or workunit object
         :param space: the execution space
-        :param types_signature: optional identifier string for inferred types of parameters
+        :param types_signature: optional identifier/hash string for types of parameters against workunit module
         :returns: a unique tuple per entity and space
         """
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -12,7 +12,7 @@ from pykokkos.core.visitors import visitors_util
 from pykokkos.interface import (
     DataType, ExecutionPolicy, ExecutionSpace, MemorySpace,
     RandomPool, RangePolicy, TeamPolicy, View, ViewType, UpdatedTypes, UpdatedDecorator,
-    is_host_execution_space, get_types_sig
+    is_host_execution_space, get_types_signature
 )
 import pykokkos.kokkos_manager as km
 
@@ -126,7 +126,7 @@ class Runtime:
                 raise RuntimeError("ERROR: operation cannot be None for Debug")
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)
 
-        types_signature: str = get_types_sig(updated_types, updated_decorator, execution_space)
+        types_signature: str = get_types_signature(updated_types, updated_decorator, execution_space)
         members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature)
         if members is None:
             raise RuntimeError("ERROR: members cannot be none")

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -78,7 +78,7 @@ class Runtime:
                                                                           updated_types, types_signature)
 
         return members
-    
+
     def compile_into_module(
         self,
         main: Path,

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -53,7 +53,7 @@ from .views import (
 )
 
 from .ext_module import compile_into_module
-from .args_type_inference import UpdatedTypes, get_annotations, get_type_str
+from .args_type_inference import UpdatedTypes, UpdatedDecorator, get_annotations, get_type_str
 
 def fence():
     pass

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -53,7 +53,7 @@ from .views import (
 )
 
 from .ext_module import compile_into_module
-from .args_type_inference import UpdatedTypes, UpdatedDecorator, get_annotations, get_type_str
+from .args_type_inference import UpdatedTypes, UpdatedDecorator, get_annotations, get_type_str, get_types_sig
 
 def fence():
     pass

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -53,7 +53,7 @@ from .views import (
 )
 
 from .ext_module import compile_into_module
-from .args_type_inference import UpdatedTypes, UpdatedDecorator, get_annotations, get_type_str, get_types_sig
+from .args_type_inference import UpdatedTypes, UpdatedDecorator, get_annotations, get_type_str, get_types_signature
 
 def fence():
     pass

--- a/pykokkos/interface/args_type_inference.py
+++ b/pykokkos/interface/args_type_inference.py
@@ -1,10 +1,9 @@
 import inspect
 from dataclasses import dataclass
-from typing import  Callable, Dict, Optional, Tuple, Union, List, Any
+from typing import  Callable, Dict, Optional, Tuple, Union, List
 import pykokkos.kokkos_manager as km
 from .execution_policy import MDRangePolicy, TeamPolicy, TeamThreadRange, RangePolicy, ExecutionPolicy, ExecutionSpace
 from .views import View, ViewType
-from .layout import Layout, get_default_layout
 from .data_types import DataType, DataTypeClass
 from hashlib import md5
 
@@ -249,10 +248,7 @@ def infer_policy_args(
 
 
 def infer_other_args(
-    param_list: List[inspect.Parameter], 
-    # policy_params: int,
-    # args_list: List[Any],
-    # start_idx: int,
+    param_list: List[inspect.Parameter],
     passed_kwargs,
     updated_types: UpdatedTypes
     ) -> UpdatedTypes:

--- a/pykokkos/interface/args_type_inference.py
+++ b/pykokkos/interface/args_type_inference.py
@@ -6,6 +6,7 @@ from .execution_policy import MDRangePolicy, TeamPolicy, TeamThreadRange, RangeP
 from .views import View, ViewType
 from .layout import Layout, get_default_layout
 from .data_types import DataType, DataTypeClass
+from hashlib import md5
 
 @dataclass
 class HandledArgs:
@@ -129,7 +130,7 @@ def get_annotations(parallel_type: str, handled_args: HandledArgs, *args, passed
     for param in param_list:
         if param.annotation is inspect._empty:
             missing = True
-    if not missing: return None
+            break
 
     # accumulator 
     if parallel_type == "parallel_reduce":
@@ -325,17 +326,7 @@ def get_types_sig(inferred_types: Dict[str, str], inferred_layouts: Dict[str, st
             signature += name + l_type
 
     # Compacting
-    signature = signature.replace("View", "")
-    signature = signature.replace("Acc:", "" )
-    signature = signature.replace("TeamMember", "T")
-    signature = signature.replace("numpy:", "np")
-    signature = signature.replace("LayoutRight", "R")
-    signature = signature.replace("LayoutLeft", "L")
-    signature = signature.replace(":", "")
-    signature = signature.replace("double", "d")
-    signature = signature.replace("int", "i")
-    signature = signature.replace("bool", "b")
-    signature = signature.replace("float", "f")
+    signature = md5(signature, usedforsecurity= False).hexdigest()
 
     return signature
 

--- a/pykokkos/interface/args_type_inference.py
+++ b/pykokkos/interface/args_type_inference.py
@@ -1,11 +1,13 @@
 import inspect
 from dataclasses import dataclass
 from typing import  Callable, Dict, Optional, Tuple, Union, List
+import hashlib
+
 import pykokkos.kokkos_manager as km
 from .execution_policy import MDRangePolicy, TeamPolicy, TeamThreadRange, RangePolicy, ExecutionPolicy, ExecutionSpace
 from .views import View, ViewType, Trait
 from .data_types import DataType, DataTypeClass
-from hashlib import md5
+
 
 @dataclass
 class HandledArgs:
@@ -183,7 +185,8 @@ def get_views_decorator(handled_args: HandledArgs, passed_kwargs) -> UpdatedDeco
         if not isinstance(value, View):
             continue
 
-        if kwarg not in updated_decorator.inferred_decorator: updated_decorator.inferred_decorator[kwarg] = {}
+        if kwarg not in updated_decorator.inferred_decorator: 
+            updated_decorator.inferred_decorator[kwarg] = {}
         updated_decorator.inferred_decorator[kwarg]['trait'] = str(value.trait).split(".")[1]
         updated_decorator.inferred_decorator[kwarg]['layout'] = str(value.layout).split(".")[1]
         updated_decorator.inferred_decorator[kwarg]['space'] = str(value.space).split(".")[1]
@@ -305,7 +308,7 @@ def infer_other_args(
 
 def get_pk_datatype(view_dtype):
     '''
-    Infer the dataype of view e.g pk.View1D[<dinfer this>]
+    Infer the dataype of view e.g pk.View1D[<infer this>]
 
     :param view_dtype: view.dtype whose datatype is to be determined as string
     :returns: the type of custom pkDataType as string
@@ -324,7 +327,7 @@ def get_pk_datatype(view_dtype):
     return dtype
 
 
-def get_types_sig(updated_types: UpdatedTypes, updated_decorator: UpdatedDecorator, execution_space: ExecutionSpace) -> str:
+def get_types_signature(updated_types: UpdatedTypes, updated_decorator: UpdatedDecorator, execution_space: ExecutionSpace) -> str:
     '''
     Generates a signature/hash to represent the signature of the workunit: used for module setup
 
@@ -351,7 +354,7 @@ def get_types_sig(updated_types: UpdatedTypes, updated_decorator: UpdatedDecorat
         return None
 
     # Compacting
-    signature = md5(signature.encode()).hexdigest()
+    signature = hashlib.md5(signature.encode()).hexdigest()
 
     return signature
 

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -7,7 +7,7 @@ import pykokkos.kokkos_manager as km
 
 from .execution_policy import ExecutionPolicy
 from .execution_space import ExecutionSpace
-from .args_type_inference import UpdatedTypes, UpdatedDecorator, HandledArgs, get_annotations, get_views_decorator, handle_args, get_types_sig
+from .args_type_inference import UpdatedTypes, UpdatedDecorator, HandledArgs, get_annotations, get_views_decorator, handle_args
 
 workunit_cache: Dict[int, Callable] = {}
 

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -101,13 +101,6 @@ def parallel_for(*args, **kwargs) -> None:
 
     updated_types: UpdatedTypes = get_annotations("parallel_for", handled_args, args, passed_kwargs=kwargs)
     updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
-    # set types signature with layouts/inferred info
-    if updated_types is not None:
-        updated_types.types_signature = get_types_sig(updated_types.inferred_types, updated_decorator.inferred_decorator)
-        print("SIGNATURE", updated_types.types_signature)
-
-    # print("UPDATED DECOR:", updated_decorator.inferred_decorator)
-    # print("inferred types:", updated_types.inferred_types)
 
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
@@ -157,13 +150,6 @@ def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
     #* Inferring missing data types
     updated_types: UpdatedTypes = get_annotations("parallel_"+operation, handled_args, args, passed_kwargs=kwargs)
     updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
-    # set types signature with layouts/inferred info
-    if updated_types is not None:
-        updated_types.types_signature = get_types_sig(updated_types.inferred_types, updated_decorator.inferred_decorator)
-        print("SIGNATURE", updated_types.types_signature)
-
-    # print("UPDATED DECOR:", updated_decorator.inferred_decorator)
-    # print("inferred types:", updated_types.inferred_types)
 
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -7,7 +7,7 @@ import pykokkos.kokkos_manager as km
 
 from .execution_policy import ExecutionPolicy
 from .execution_space import ExecutionSpace
-from .args_type_inference import UpdatedTypes, HandledArgs, get_annotations, handle_args
+from .args_type_inference import UpdatedTypes, UpdatedDecorator, HandledArgs, get_annotations, get_views_decorator, handle_args, get_types_sig
 
 workunit_cache: Dict[int, Callable] = {}
 
@@ -100,11 +100,20 @@ def parallel_for(*args, **kwargs) -> None:
     handled_args: HandledArgs = handle_args(True, args)
 
     updated_types: UpdatedTypes = get_annotations("parallel_for", handled_args, args, passed_kwargs=kwargs)
+    updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
+    # set types signature with layouts/inferred info
+    if updated_types is not None:
+        updated_types.types_signature = get_types_sig(updated_types.inferred_types, updated_decorator.inferred_decorator)
+        print("SIGNATURE", updated_types.types_signature)
+
+    # print("UPDATED DECOR:", updated_decorator.inferred_decorator)
+    # print("inferred types:", updated_types.inferred_types)
 
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,
         handled_args.workunit,
+        updated_decorator,
         updated_types,
         "for",
         **kwargs)
@@ -147,11 +156,20 @@ def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
 
     #* Inferring missing data types
     updated_types: UpdatedTypes = get_annotations("parallel_"+operation, handled_args, args, passed_kwargs=kwargs)
+    updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
+    # set types signature with layouts/inferred info
+    if updated_types is not None:
+        updated_types.types_signature = get_types_sig(updated_types.inferred_types, updated_decorator.inferred_decorator)
+        print("SIGNATURE", updated_types.types_signature)
+
+    # print("UPDATED DECOR:", updated_decorator.inferred_decorator)
+    # print("inferred types:", updated_types.inferred_types)
 
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,
         handled_args.workunit,
+        updated_decorator,
         updated_types,
         operation,
         **kwargs)

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -1,9 +1,10 @@
 import unittest
 import numpy as np
 import pykokkos as pk
+import pytest
 try:
     import cupy as cp
-    HAS_CUDA = False
+    HAS_CUDA = True
 except ImportError:
     HAS_CUDA = False
 
@@ -139,6 +140,7 @@ class TestTypeInference(unittest.TestCase):
         for i in range(0, self.threads):
             self.assertEqual(expected_result, self.view1D[i])
 
+    @pytest.mark.skipif(not HAS_CUDA, reason="CUDA/cupy not available")
     def test_simple_parallelfor_cuda(self):
         if not HAS_CUDA:
             return
@@ -155,6 +157,7 @@ class TestTypeInference(unittest.TestCase):
         result = pk.parallel_reduce(self.range_policy, reduce, view=self.view1D)
         self.assertEqual(expect_result, result)
 
+    @pytest.mark.skipif(not HAS_CUDA, reason="CUDA/cupy not available")
     def test_simple_parallelreduce_cuda(self):
         if not HAS_CUDA:
             return
@@ -173,6 +176,7 @@ class TestTypeInference(unittest.TestCase):
         for i in range(0, self.threads):
             self.assertEqual(expect_result[i], self.view1D[i])
 
+    @pytest.mark.skipif(not HAS_CUDA, reason="CUDA/cupy not available")
     def test_simple_parallelscan_cuda(self):
         if not HAS_CUDA:
             return
@@ -245,6 +249,7 @@ class TestTypeInference(unittest.TestCase):
         self.assertEqual(int64_view.layout, pk.Layout.LayoutRight)
         self.assertEqual(int64_view[0], self.np_i64)
 
+    @pytest.mark.skipif(not HAS_CUDA, reason="CUDA/cupy not available")
     def test_cuda_switch(self):
         if not HAS_CUDA:
             return
@@ -317,6 +322,7 @@ class TestTypeInference(unittest.TestCase):
                 for k in range(self.threads):
                     self.assertEqual(self.view3D[i][j][k], expect_result)
 
+    @pytest.mark.skipif(not HAS_CUDA, reason="CUDA/cupy not available")
     def test_all_Ds_cuda(self):
         if not HAS_CUDA:
             return

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -367,4 +367,3 @@ class TestTypeInference(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -123,14 +123,16 @@ class TestTypeInference(unittest.TestCase):
         self.np_u64: np.uint64 = np.uint64(2**64 -1)
 
         self.range_policy = pk.RangePolicy(pk.ExecutionSpace.Default, 0, self.threads)
-        self.range_policy_cuda = pk.RangePolicy(pk.ExecutionSpace.Cuda, 0, self.threads)
         self.team_policy =  pk.TeamPolicy(self.threads, pk.AUTO)
         self.view1D: pk.View1D[pk.int32] = pk.View([self.threads], pk.int32)
-        self.view1D_cuda: pk.View1D[pk.int32] = pk.View([self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
         self.view2D: pk.View2D[pk.int32] = pk.View([self.threads, self.threads], pk.int32)
-        self.view2D_cuda: pk.View1D[pk.int32] = pk.View([self.threads, self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
         self.view3D: pk.View3D[pk.int32] = pk.View([self.threads, self.threads, self.threads], pk.int32)
-        self.view3D_cuda: pk.View3D[pk.int32] = pk.View([self.threads, self.threads, self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
+
+        if HAS_CUDA:
+            self.range_policy_cuda = pk.RangePolicy(pk.ExecutionSpace.Cuda, 0, self.threads)
+            self.view1D_cuda: pk.View1D[pk.int32] = pk.View([self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
+            self.view2D_cuda: pk.View1D[pk.int32] = pk.View([self.threads, self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
+            self.view3D_cuda: pk.View3D[pk.int32] = pk.View([self.threads, self.threads, self.threads], pk.int32, pk.CudaSpace, pk.LayoutLeft)
 
 
     def test_simple_parallelfor(self):

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -432,6 +432,4 @@ class TestTypeInference(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-    # test = TestTypeInference()
-    # test.setUp()
-    # test.test_layout_switchL()
+

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -432,4 +432,3 @@ class TestTypeInference(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -99,6 +99,9 @@ def add_all_init(i, view, i8, i16, i32, i64):
 def add_two_init(i, view, v1, v2):
     view[i] = v1 + v2
 
+@pk.workunit
+def no_view(i: int, acc: pk.Acc[pk.double], n):
+    acc=acc + n;
 
 class TestTypeInference(unittest.TestCase):
     def setUp(self):
@@ -298,10 +301,10 @@ class TestTypeInference(unittest.TestCase):
         pk.parallel_for(self.range_policy, init_view_layout, view=l_view, init=1)
         self.assertEqual(l_view.layout, pk.Layout.LayoutLeft)
 
-    # def test_only_layoutL(self):
-    #     l_view = pk.View([self.threads], pk.int32, layout=pk.Layout.LayoutLeft)
-    #     pk.parallel_for(self.range_policy, init_view_annotated, view=l_view, init=self.np_i32)
-    #     self.assertEqual(l_view.layout, pk.Layout.LayoutLeft)
+    def test_only_layoutL(self):
+        l_view = pk.View([self.threads], pk.int32, layout=pk.Layout.LayoutLeft)
+        pk.parallel_for(self.range_policy, init_view_annotated, view=l_view, init=self.np_i32)
+        self.assertEqual(l_view.layout, pk.Layout.LayoutLeft)
 
     def test_only_layoutR(self):
         r_view = pk.View([self.threads], pk.int32, layout=pk.Layout.LayoutRight)
@@ -356,6 +359,12 @@ class TestTypeInference(unittest.TestCase):
         result = pk.parallel_reduce(p, team_reduce_mixed, M=self.threads, y=new_view, x=x, A=A)
         self.assertEqual(result, expected_result)
 
+    def test_no_view(self):
+        pk.parallel_reduce(self.range_policy, no_view, n = 1);
+        pk.parallel_reduce(self.range_policy, no_view, n = 2.1);
+
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
In continuation to previous version of type inference, now introducing a series of improvements:
- Decorator specifiers logic has been made separate from type inference - and these decorators will always override user provided ones
- Refactored to simplify type inference
- Keyword arguments can now be passed in any order with respect to the signature for inference to work
- Separated AST injection/fix calls for type annotation insertion and decorator insertion