### PR TITLE
docker: Set up for building our image and running tests/code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu
+
+ENV HOME_DIR /home/pk
+
+# Install base utilities.
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get install -y wget \
+    && apt-get install -y git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# https://stackoverflow.com/questions/27701930/how-to-add-users-to-docker-container
+RUN useradd --create-home --shell /bin/bash pk
+USER pk
+WORKDIR $HOME_DIR
+
+# Install miniconda.
+ENV CONDA_DIR $HOME_DIR/opt/conda
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+/bin/bash ~/miniconda.sh -b -p $HOME_DIR/opt/conda
+
+# Put conda on the path so we can use the command.
+ENV PATH=$CONDA_DIR/bin:$PATH
+
+# Get pykokkos.
+RUN git clone https://github.com/kokkos/pykokkos-base
+
+# Install dependencies.
+RUN conda install -c conda-forge --yes mamba
+RUN conda init
+RUN mamba install -c conda-forge --yes --file pykokkos-base/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN mamba install -c conda-forge --yes --file /tmp/requirements.txt
+RUN cd pykokkos-base && python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=3 -DENABLE_CUDA=OFF -DENABLE_THREADS=OFF -DENABLE_OPENMP=ON

--- a/pk
+++ b/pk
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+PROJECT="pykokkos"
+TAG="latest"
+CHOME="/home/pk"
+
+
+# ----------
+# Functions.
+
+function docker_clean() {
+        # Clean docker containers and images (this function is
+        # aggressive and cleans a lot more than necessary). Run only
+        # if you know the risk.
+
+        docker ps -a | grep -v 'CONTA' | cut -f1 -d' ' | xargs -I xxx docker rm xxx
+        docker images | grep "${PROJECT}" | awk '{ print $3 }' | xargs -I xxx docker image rm xxx
+        docker images | grep '<none>' | awk '{ print $3 }' | xargs -I xxx docker image rm xxx
+}
+
+function docker_build() {
+        local -r tag="${1:-$TAG}"
+
+        [ -z "${tag}" ] && return 1
+        [ ! -f "Dockerfile" ] && return 1
+
+        docker build -t "${PROJECT}:${tag}" -f Dockerfile .
+}
+
+function test_cmd_container() {
+        ( cd "${CHOME}/pykokkos"
+          python runtests.py )
+}
+
+function cmd_in_container() {
+        local -r name="${1}"
+
+        ( cd "${CHOME}/pykokkos"
+          export PYTHONPATH=pykokkos:$PYTHONPATH
+          python "${name}" )
+}
+
+function run_example() {
+        local -r name="${1}"
+
+        [ -z "${name}" ] && \
+                { echo "no example name provided"; return 1; }
+
+        docker run --volume $(pwd):"${CHOME}/pykokkos" \
+               "${PROJECT}" \
+               "${CHOME}/pykokkos/pk" "cmd_in_container" "${name}"
+}
+
+function run_tests() {
+        run_example "runtests.py"
+}
+
+"$@"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pybind11>=2.11.1
+cupy>=12.2.0
+patchelf>=0.17.2
+pytest>=7.4.3
+python=3.11


### PR DESCRIPTION
The goal of this PR is to enable us to run pykokkos in a docker container. The items included:
  * Dockerfile to let us build the image (this is focusing on CPU runs at the moment)
  * Script that can use pykkokos image to run tests and examples in a container
  * requirements.txt to ensure more control over versioning

Some decision decisions:
 * Use `pykokkos` as the name for the image (note that later we might add other images for `-cuda` or `-hip`). Maybe `-cpu` could be added, but I did not feel like it.
 * Use `pk` as the username (because I felt there are many pykokkos things around already).
 * Potentially went a bit too far with being strict on version numbers, but felt good about it (as we can relax things in the future)

One thing we will probably want to add into the `pk` script is to pull the the pykokkos image if one is not present.