### PR TITLE
Build python bindings with the same cxx standard as kokkos.

### DIFF
--- a/pykokkos/core/compile.sh
+++ b/pykokkos/core/compile.sh
@@ -13,6 +13,8 @@ LIB_SUFFIX="${10}"
 COMPILER_PATH="${11}"
 SRC=$(find -name "*.cpp")
 
+# set CXX standard to be the same as in KokkosCore_config.h
+CXX_STANDARD=$(g++ -dM -E -DKOKKOS_MACROS_HPP ${KOKKOS_INCLUDE_PATH}/KokkosCore_config.h | grep KOKKOS_ENABLE_CXX | tr -d ' ' | sed -e 's/.*\(..\)$/\1/')
 
 if [ "${COMPILER}" == "g++" ]; then
         g++ \
@@ -21,7 +23,7 @@ if [ "${COMPILER}" == "g++" ]; then
         -O3 \
         -isystem "${KOKKOS_INCLUDE_PATH}" \
         -fPIC \
-        -fopenmp -std=c++14 \
+        -fopenmp -std=c++${CXX_STANDARD} \
         -DSPACE="${EXEC_SPACE}" \
         -o "${SRC}".o \
         -c "${SRC}" \
@@ -47,7 +49,7 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         -isystem "${KOKKOS_INCLUDE_PATH}" \
         -arch="${COMPUTE_CAPABILITY}" \
         --expt-extended-lambda -fPIC \
-        -Xcompiler -fopenmp -std=c++14 \
+        -Xcompiler -fopenmp -std=c++${CXX_STANDARD} \
         -DSPACE="${EXEC_SPACE}" \
         -o "${SRC}".o \
         -c "${SRC}" \
@@ -74,7 +76,7 @@ elif [ "${COMPILER}" == "hipcc" ]; then
         -O3 \
         -isystem "${KOKKOS_INCLUDE_PATH}" \
         -fPIC -fno-gpu-rdc \
-        -fopenmp -std=c++14 \
+        -fopenmp -std=c++${CXX_STANDARD} \
         -DSPACE="${EXEC_SPACE}" \
         -o "${SRC}".o \
         -c "${SRC}" \


### PR DESCRIPTION
A tentative fix for #215 