### PR TITLE
Fix matching of view names to types and add march=native to compile.sh

### DIFF
--- a/pykokkos/core/compile.sh
+++ b/pykokkos/core/compile.sh
@@ -21,6 +21,7 @@ if [ "${COMPILER}" == "g++" ]; then
         `python3 -m pybind11 --includes` \
         -I.. \
         -O3 \
+        -march=native -mtune=native \
         -isystem "${KOKKOS_INCLUDE_PATH}" \
         -fPIC \
         -fopenmp -std=c++${CXX_STANDARD} \
@@ -46,6 +47,7 @@ elif [ "${COMPILER}" == "nvcc" ]; then
         `python3 -m pybind11 --includes` \
         -I.. \
         -O3 \
+        -Xcompiler -march=native -Xcompiler -mtune=native \
         -isystem "${KOKKOS_INCLUDE_PATH}" \
         -arch="${COMPUTE_CAPABILITY}" \
         --expt-extended-lambda -fPIC \

--- a/pykokkos/core/visitors/kokkosfunction_visitor.py
+++ b/pykokkos/core/visitors/kokkosfunction_visitor.py
@@ -78,6 +78,15 @@ class KokkosFunctionVisitor(PyKokkosVisitor):
                 # function arguments.
                 continue
 
+            fused_arg: re.Pattern = re.compile(f"fused_.*_[0-9]+")
+            if fused_arg.match(arg.arg):
+                original_view: str = arg.arg.split("_")[1]
+                original = cppast.DeclRefExpr(original_view)
+
+                if original in self.views:
+                    self.views[declref] = self.views[cppast.DeclRefExpr(original_view)]
+                    continue
+
             decltype: Optional[cppast.Type] = visitors_util.get_type(arg.annotation, self.pk_import)
             if isinstance(decltype, cppast.ClassType) and decltype.typename.startswith("View"):
                 self.views[declref] = decltype


### PR DESCRIPTION
In order to get the view types in functions decorated with `@pk.function`, we have to match the original view names with the fused view names. This PR adds that functionality to the KokkosFunctionVisitor.

Additionally, this PR adds the `-march=native -mtune=native` to the compile command in compile.sh for better performance.