### PR TITLE
Add option to fuse kernel arguments

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -50,7 +50,7 @@ class Compiler:
         logging.basicConfig(stream=sys.stdout, level=numeric_level)
         self.logger = logging.getLogger()
 
-    def fuse_objects(self, metadata: List[EntityMetadata], fuse_ASTs: bool) -> Tuple[PyKokkosEntity, List[PyKokkosEntity]]:
+    def fuse_objects(self, metadata: List[EntityMetadata], fuse_ASTs: bool, **kwargs) -> Tuple[PyKokkosEntity, List[PyKokkosEntity]]:
         """
         Fuse two or more workunits into one
 
@@ -98,7 +98,7 @@ class Compiler:
 
         fused_name: str = "_".join(names)
         if fuse_ASTs:
-            AST, source = fuse_workunits(fused_name, ASTs, sources)
+            AST, source = fuse_workunits(fused_name, ASTs, sources, **kwargs)
         else:
             AST = None
             source = None
@@ -115,7 +115,8 @@ class Compiler:
         force_uvm: bool,
         updated_decorator: UpdatedDecorator,
         updated_types: Optional[UpdatedTypes] = None,
-        types_signature: Optional[str] = None
+        types_signature: Optional[str] = None,
+        **kwargs
     ) -> Optional[PyKokkosMembers]:
         """
         Compile an entity object for a single execution space
@@ -139,7 +140,7 @@ class Compiler:
             classtypes = parser.get_classtypes()
         else:
             # Avoid fusing the ASTs before checking if it was already compiled
-            entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=False)
+            entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=False, **kwargs)
 
         hash: str = self.members_hash(entity.path, entity.name, types_signature)
 
@@ -152,7 +153,7 @@ class Compiler:
         if self.is_compiled(module_setup.output_dir):
             if hash not in self.members: # True if pre-compiled
                 if len(metadata) > 1:
-                    entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=True)
+                    entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=True, **kwargs)
 
                 if types_inferred:
                     entity.AST = parser.fix_types(entity, updated_types)
@@ -163,7 +164,7 @@ class Compiler:
             return self.members[hash]
 
         if len(metadata) > 1:
-            entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=True)
+            entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=True, **kwargs)
 
         self.is_compiled_cache[module_setup.output_dir] = True
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -61,6 +61,7 @@ class Runtime:
         updated_decorator: UpdatedDecorator,
         updated_types: Optional[UpdatedTypes] = None,
         types_signature: Optional[str] = None,
+        **kwargs,
     ) -> Optional[PyKokkosMembers]:
         """
         precompile the workunit
@@ -76,7 +77,7 @@ class Runtime:
         members: Optional[PyKokkosMembers] = self.compiler.compile_object(module_setup, 
                                                                           space, km.is_uvm_enabled(), 
                                                                           updated_decorator, 
-                                                                          updated_types, types_signature)
+                                                                          updated_types, types_signature, **kwargs)
 
         return members
 
@@ -128,7 +129,7 @@ class Runtime:
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)
 
         types_signature: str = get_types_signature(updated_types, updated_decorator, execution_space)
-        members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature)
+        members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature, **kwargs)
         if members is None:
             raise RuntimeError("ERROR: members cannot be none")
 


### PR DESCRIPTION
Use `id()` to identify arguments passed to fused workunits that are the same and combine them into a single argument. Currently guarded with an environment variable.