### PR TITLE
Removing dependence on inspect

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -114,7 +114,7 @@ class Compiler:
         module_setup: ModuleSetup,
         space: ExecutionSpace,
         force_uvm: bool,
-        updated_decorator: UpdatedDecorator,
+        updated_decorator: Optional[UpdatedDecorator] = None,
         updated_types: Optional[UpdatedTypes] = None,
         types_signature: Optional[str] = None,
         **kwargs

--- a/pykokkos/core/fusion/fuse.py
+++ b/pykokkos/core/fusion/fuse.py
@@ -52,40 +52,41 @@ class VariableRenamer(ast.NodeTransformer):
 
 
 def fuse_workunit_kwargs_and_params(
-    workunits: List[Callable],
+    workunit_tree_tuples: List[Tuple[Callable, ast.AST]],
     kwargs: Dict[str, Any]
-) -> Tuple[Dict[str, Any], List[inspect.Parameter]]:
+) -> Tuple[Dict[str, Any], List[ast.arg]]:
     """
     Fuse the parameters and runtime arguments of a list of workunits and rename them as necessary
 
-    :param workunits: the list of workunits being merged
+    :param workunits_tree_tuples: the list of workunits and their trees being merged
     :param kwargs: the keyword arguments passed to the call
     :returns: a tuple of the fused kwargs and the combined inspected parameters
     """
 
     fused_kwargs: Dict[str, Any] = {}
-    fused_params: List[inspect.Parameter] = []
-    fused_params.append(inspect.Parameter("fused_tid", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=int))
+    fused_params: List[ast.arg] = []
+    fused_params.append(ast.arg(arg="fused_tid", annotation=int))
 
     view_ids: Set[int] = set()
 
-    for workunit_idx, workunit in enumerate(workunits):
+    for workunit_idx, tup in enumerate(workunit_tree_tuples):
+        _ , tree = tup
         key: str = f"args_{workunit_idx}"
         if key not in kwargs:
             raise RuntimeError(f"kwargs not specified for workunit {workunit_idx} with key {key}")
         current_kwargs: Dict[str, Any] = kwargs[key]
 
-        current_params: List[inspect.Parameter] = list(inspect.signature(workunit).parameters.values())
+        current_params: List[ast.arg] = [p for p in tree.args.args]
         for p in current_params[1:]: # Skip the thread ID
-            current_arg = current_kwargs[p.name]
+            current_arg = current_kwargs[p.arg]
             if "PK_FUSE_ARGS" in os.environ and id(current_arg) in view_ids:
                 continue
 
             view_ids.add(id(current_arg))
 
-            fused_name: str = f"fused_{p.name}_{workunit_idx}"
-            fused_kwargs[fused_name] = current_kwargs[p.name]
-            fused_params.append(inspect.Parameter(fused_name, p.kind, annotation=p.annotation))
+            fused_name: str = f"fused_{p.arg}_{workunit_idx}"
+            fused_kwargs[fused_name] = current_kwargs[p.arg]
+            fused_params.append(ast.arg(arg=fused_name, annotation=p.annotation))
 
     return fused_kwargs, fused_params
 

--- a/pykokkos/core/fusion/fuse.py
+++ b/pykokkos/core/fusion/fuse.py
@@ -52,13 +52,13 @@ class VariableRenamer(ast.NodeTransformer):
 
 
 def fuse_workunit_kwargs_and_params(
-    workunit_tree_tuples: List[Tuple[Callable, ast.AST]],
+    workunit_trees: List[ast.AST],
     kwargs: Dict[str, Any]
 ) -> Tuple[Dict[str, Any], List[ast.arg]]:
     """
     Fuse the parameters and runtime arguments of a list of workunits and rename them as necessary
 
-    :param workunits_tree_tuples: the list of workunits and their trees being merged
+    :param workunits_trees: the list of workunit trees (ASTs) being merged
     :param kwargs: the keyword arguments passed to the call
     :returns: a tuple of the fused kwargs and the combined inspected parameters
     """
@@ -69,8 +69,7 @@ def fuse_workunit_kwargs_and_params(
 
     view_ids: Set[int] = set()
 
-    for workunit_idx, tup in enumerate(workunit_tree_tuples):
-        _ , tree = tup
+    for workunit_idx, tree in enumerate(workunit_trees):
         key: str = f"args_{workunit_idx}"
         if key not in kwargs:
             raise RuntimeError(f"kwargs not specified for workunit {workunit_idx} with key {key}")

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -1,6 +1,4 @@
 import ast
-import copy
-import inspect
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable, Dict, List, Optional, Tuple, Union

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -201,7 +201,7 @@ class Parser:
         param_list = updated_obj.param_list
         for param in param_list:
             arg_obj = ast.arg(arg=param.name)
-            if param.annotation is not inspect._empty:
+            if param.annotation is not None:
                 type_str = get_type_str(param.annotation)  # simplify inspect.annotation to string
                 arg_obj.annotation = self.get_annotation_node(type_str)
             args_list.append(arg_obj)

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -141,7 +141,7 @@ class Runtime:
         updated_decorator: Optional[UpdatedDecorator]
         types_signature: Optional[str]
     
-        updated_types, updated_decorator, types_signature = get_type_info(parser, policy, operation, workunit, kwargs)
+        updated_types, updated_decorator, types_signature = get_type_info(operation, parser, policy, workunit, kwargs)
 
         members: Optional[PyKokkosMembers] = self.precompile_workunit(workunit, execution_space, updated_decorator, updated_types, types_signature, **kwargs)
         if members is None:

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -153,8 +153,15 @@ class Runtime:
                 entity_AST.append(this_tree)
                 continue
 
-            is_missing_annotations: bool = check_missing_annotations(this_tree.args.args)
-            if is_missing_annotations: # cache original state, we need inference
+            is_missing_annotations: bool = (
+                workunit_str in self.workunit_params
+                or
+                list_passed
+                or
+                check_missing_annotations(this_tree.args.args)
+                )
+
+            if is_missing_annotations:
                 if workunit_str in self.workunit_params:
                     this_tree.args.args = pickle.loads(self.workunit_params[workunit_str])
                 else:

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -147,6 +147,12 @@ class Runtime:
             this_tree = parser.get_entity(this_metadata.name).AST
 
             # check if this is the first run of this workunit
+            if not isinstance(this_tree, ast.FunctionDef):
+                # Workunit must be a function on its own (not in a functor)
+                is_standalone_workunit = False
+                entity_AST.append(this_tree)
+                continue
+
             if str(this_workunit) in self.workunit_params:
                 this_tree.args = copy.deepcopy(self.workunit_params[str(this_workunit)])
             else:
@@ -154,10 +160,6 @@ class Runtime:
                 self.workunit_params[str(this_workunit)] = copy.deepcopy(this_tree.args)
             
             entity_AST.append(this_tree)
-
-        # Workunit must be a function on its own (not in a functor)
-        if not isinstance(entity_AST[0], ast.FunctionDef):
-            is_standalone_workunit = False
 
         workunit_tree_tup = list(zip(workunit, entity_AST))
 

--- a/pykokkos/core/type_inference/__init__.py
+++ b/pykokkos/core/type_inference/__init__.py
@@ -1,5 +1,5 @@
 from .args_type_inference import (
     UpdatedTypes, UpdatedDecorator, HandledArgs,
     handle_args, get_annotations, get_type_str, get_types_signature,
-    get_views_decorator
+    get_views_decorator, check_missing_annotations
 )

--- a/pykokkos/core/type_inference/__init__.py
+++ b/pykokkos/core/type_inference/__init__.py
@@ -1,5 +1,4 @@
 from .args_type_inference import (
     UpdatedTypes, UpdatedDecorator, HandledArgs,
-    handle_args, get_annotations, get_type_str, get_types_signature,
-    get_views_decorator, prepare_fusion_args, process_arg_nodes
+    handle_args, get_type_str, get_type_info
 )

--- a/pykokkos/core/type_inference/__init__.py
+++ b/pykokkos/core/type_inference/__init__.py
@@ -1,5 +1,5 @@
 from .args_type_inference import (
     UpdatedTypes, UpdatedDecorator, HandledArgs,
     handle_args, get_annotations, get_type_str, get_types_signature,
-    get_views_decorator, check_missing_annotations
+    get_views_decorator, check_missing_annotations, prepare_runtime_args
 )

--- a/pykokkos/core/type_inference/__init__.py
+++ b/pykokkos/core/type_inference/__init__.py
@@ -1,5 +1,5 @@
 from .args_type_inference import (
     UpdatedTypes, UpdatedDecorator, HandledArgs,
     handle_args, get_annotations, get_type_str, get_types_signature,
-    get_views_decorator, check_missing_annotations, prepare_runtime_args
+    get_views_decorator, prepare_fusion_args, process_arg_nodes
 )

--- a/pykokkos/core/type_inference/args_type_inference.py
+++ b/pykokkos/core/type_inference/args_type_inference.py
@@ -119,8 +119,8 @@ def get_annotations(parallel_type: str, workunit_tree_tuples: Union[Tuple[Callab
     Infer the datatypes for arguments passed against workunit parameters
 
     :param parallel_type: A string identifying the type of parallel dispatch ("parallel_for", "parallel_reduce" ...)
-    :param handled_args: Processed arguments passed to the dispatch
-    :param args: raw arguments passed to the dispatch
+    :param workunit_tree_tuples: workunit object and its tree in tuples. Can be a list or standalone
+    :param policy: The execution policy for this parallel dispatch - used to handle policy args
     :param passed_kwargs: raw keyword arguments passed to the dispatch
     :returns: UpdateTypes object or None if there are no annotations to be inferred
     '''

--- a/pykokkos/core/type_inference/args_type_inference.py
+++ b/pykokkos/core/type_inference/args_type_inference.py
@@ -113,6 +113,19 @@ def handle_args(is_for: bool, *args) -> HandledArgs:
 
     return HandledArgs(name, policy, workunit, view, initial_value)
 
+def check_missing_annotations(param_list: List[ast.arg]) -> bool:
+    '''
+    :param param_list: list of ast.arg objects to run annotation check against
+
+    :returns: True if any parameter is missing annotation, false otherwise
+    '''
+
+    missing = False
+    for param in param_list:
+        if param.annotation is None:
+            missing = True
+            break
+    return missing
 
 def get_annotations(parallel_type: str, workunit_tree_tuples: Union[Tuple[Callable, ast.AST], List[Tuple[Callable, ast.AST]]], policy: Union[ExecutionPolicy, int], passed_kwargs) -> Optional[UpdatedTypes]:
     '''

--- a/pykokkos/core/type_inference/args_type_inference.py
+++ b/pykokkos/core/type_inference/args_type_inference.py
@@ -124,22 +124,18 @@ def get_annotations(parallel_type: str, workunit_tree_tuples: Union[Tuple[Callab
     :param passed_kwargs: raw keyword arguments passed to the dispatch
     :returns: UpdateTypes object or None if there are no annotations to be inferred
     '''
- 
+    # x.arg is param identifier (name) and x.annotation is the annotation object .id is the annotated type
     param_list: List[ast.arg]
 
     if isinstance(workunit_tree_tuples, list):
         if parallel_type != "parallel_for":
             raise RuntimeError("Can only do kernel fusion with parallel for")
-
-        passed_kwargs, param_list = fuse_workunit_kwargs_and_params(workunit_tree_tuples, passed_kwargs)
         workunit = [w for w, _ in workunit_tree_tuples]
+        trees = [t for _, t in workunit_tree_tuples]
+        passed_kwargs, param_list = fuse_workunit_kwargs_and_params(trees, passed_kwargs)
     else:
-        print("TUPLES",workunit_tree_tuples)
         workunit, entity_AST = workunit_tree_tuples
         param_list = [x for x in entity_AST.args.args]
-        print(param_list, "\n")
-        # x.arg is param identifier (name) and x.annotation is the annotation object .id is the annotated type
-        print(ast.dump(entity_AST), "\n")
 
     
     updated_types = UpdatedTypes(
@@ -192,7 +188,8 @@ def get_views_decorator(workunit_tree_tuples: List[Tuple[Callable, ast.AST]], pa
 
     param_list: List[ast.arg]
     if isinstance(workunit_tree_tuples, list):
-        passed_kwargs, param_list = fuse_workunit_kwargs_and_params(workunit_tree_tuples, passed_kwargs)
+        trees = [t for _, t in workunit_tree_tuples]
+        passed_kwargs, param_list = fuse_workunit_kwargs_and_params(trees, passed_kwargs)
         param_list = [p.arg for p in param_list]
     else:
         _, entity_AST = workunit_tree_tuples

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -54,16 +54,14 @@ def parallel_for(*args, **kwargs) -> None:
 
     handled_args: HandledArgs = handle_args(True, args)
 
-    updated_types: UpdatedTypes = get_annotations("parallel_for", handled_args, args, passed_kwargs=kwargs)
-    updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
+    # updated_types: UpdatedTypes = get_annotations("parallel_for", handled_args, args, passed_kwargs=kwargs)
+    # updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
 
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,
         handled_args.workunit,
         "for",
-        updated_decorator,
-        updated_types,
         **kwargs)
 
     # workunit_cache[cache_key] = (func, args)
@@ -102,17 +100,11 @@ def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
 
     handled_args: HandledArgs = handle_args(True, args)
 
-    #* Inferring missing data types
-    updated_types: UpdatedTypes = get_annotations(f"parallel_{operation}", handled_args, args, passed_kwargs=kwargs)
-    updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
-
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,
         handled_args.workunit,
         operation,
-        updated_decorator,
-        updated_types,
         **kwargs)
 
     workunit_cache[cache_key] = (func, args)

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -54,9 +54,6 @@ def parallel_for(*args, **kwargs) -> None:
 
     handled_args: HandledArgs = handle_args(True, args)
 
-    # updated_types: UpdatedTypes = get_annotations("parallel_for", handled_args, args, passed_kwargs=kwargs)
-    # updated_decorator: UpdatedDecorator = get_views_decorator(handled_args, passed_kwargs=kwargs)
-
     func, args = runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Union
 
 from pykokkos.runtime import runtime_singleton
 import pykokkos.kokkos_manager as km
-from pykokkos.core.type_inference import UpdatedTypes, UpdatedDecorator, HandledArgs, get_annotations, get_views_decorator, handle_args
+from pykokkos.core.type_inference import HandledArgs, handle_args
 
 from .execution_policy import ExecutionPolicy
 from .execution_space import ExecutionSpace


### PR DESCRIPTION
This PR removes dependence on inspect library for type inference pipeline. This restructure includes:
- Reading of types now happens in the runtime object in `runtime.py` using the parser.
- This means that the parser is now initialized first in `runtime.py` using the compiler object already available
- Original parameters and their annotation are now read from the workunit AST itself.
- Runtime object now has a cache for the original state of the arguments node in the AST (to reset the arguments for the next call to the workunit)
