### PR TITLE
docker: Pull the image and uniform naming

### DIFF
--- a/pk
+++ b/pk
@@ -63,7 +63,9 @@ function pk_example() {
         pk_docker_pull || \
                 { echo "could not get the docker image"; return 1; }
 
-        docker run --volume $(pwd):"${CHOME}/pykokkos" \
+        docker run \
+               --volume $(pwd):"${CHOME}/pykokkos" \
+               --user pk:$(id -g) \
                "${PROJECT}" \
                "${CHOME}/pykokkos/pk" "_pk_cmd" "${name}"
 }

--- a/pk
+++ b/pk
@@ -1,25 +1,40 @@
 #!/bin/bash
+#
+# Script to support using pykokkos docker with the pykokkos repo.
+#
+# The docker image we includes:
+# * pykokkos-base
+# * kokkos
+#
+# It does *not* include pykokkos itself. This enables developing
+# pykokkos using the same docker image. This script provide the bridge
+# by including pykokkos (this repo) as a volume.
 
-PROJECT="pykokkos"
-TAG="latest"
-CHOME="/home/pk"
+# Docker project name.
+readonly PROJECT="gligoric/pykokkos"
+
+# Docker tag.
+readonly TAG="latest"
+
+# Home directory in the container.
+readonly CHOME="/home/pk"
 
 
 # ----------
 # Functions.
 
-function docker_clean() {
+function pk_docker_clean() {
         # Clean docker containers and images (this function is
         # aggressive and cleans a lot more than necessary). Run only
         # if you know the risk.
 
         docker ps -a | grep -v 'CONTA' | cut -f1 -d' ' | xargs -I xxx docker rm xxx
-        docker images | grep "${PROJECT}" | awk '{ print $3 }' | xargs -I xxx docker image rm xxx
-        docker images | grep '<none>' | awk '{ print $3 }' | xargs -I xxx docker image rm xxx
+        docker images | grep "${PROJECT}" | awk '{ print $3 }' | xargs -I xxx docker image rm -f xxx
+        docker images | grep '<none>' | awk '{ print $3 }' | xargs -I xxx docker image rm -f xxx
 }
 
-function docker_build() {
-        local -r tag="${1:-$TAG}"
+function pk_docker_build() {
+        local -r tag="${1:-${TAG}}"
 
         [ -z "${tag}" ] && return 1
         [ ! -f "Dockerfile" ] && return 1
@@ -27,12 +42,11 @@ function docker_build() {
         docker build -t "${PROJECT}:${tag}" -f Dockerfile .
 }
 
-function test_cmd_container() {
-        ( cd "${CHOME}/pykokkos"
-          python runtests.py )
+function pk_docker_pull() {
+        docker pull "${PROJECT}:${TAG}" > /dev/null
 }
 
-function cmd_in_container() {
+function _pk_cmd() {
         local -r name="${1}"
 
         ( cd "${CHOME}/pykokkos"
@@ -40,19 +54,22 @@ function cmd_in_container() {
           python "${name}" )
 }
 
-function run_example() {
+function pk_example() {
         local -r name="${1}"
 
         [ -z "${name}" ] && \
-                { echo "no example name provided"; return 1; }
+                { echo "no name provided (e.g., examples/kokkos-tutorials/workload/01.py)"; return 1; }
+
+        pk_docker_pull || \
+                { echo "could not get the docker image"; return 1; }
 
         docker run --volume $(pwd):"${CHOME}/pykokkos" \
                "${PROJECT}" \
-               "${CHOME}/pykokkos/pk" "cmd_in_container" "${name}"
+               "${CHOME}/pykokkos/pk" "_pk_cmd" "${name}"
 }
 
-function run_tests() {
-        run_example "runtests.py"
+function pk_tests() {
+        pk_example "runtests.py"
 }
 
 "$@"


### PR DESCRIPTION
This PR changes our script for working with docker to use the actual image uploaded to the hub.
Additionally it makes the naming of functions more uniform.

Once this is merged, an example with a docker can be run like this
```
./pk pk_example examples/kokkos-tutorials/workload/01.py
```

This will pull the latest image and then run the example in a container. Running another example simply requires changing the path at the end. 