### PR TITLE
Add feature for delayed execution of kernels

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -24,6 +24,15 @@ ignore_errors = True
 [mypy-pykokkos.core.fusion.fuse]
 ignore_errors = True
 
+[mypy-pykokkos.core.fusion.trace]
+ignore_errors = True
+
+[mypy-pykokkos.core.fusion.access_modes]
+ignore_errors = True
+
+[mypy-pykokkos.core.fusion.future]
+ignore_errors = True
+
 [mypy-pykokkos.core.translators.functor]
 ignore_errors = True
 

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -2,7 +2,7 @@ import atexit
 from typing import Optional
 
 from pykokkos.runtime import runtime_singleton
-from pykokkos.core import CompilationDefaults, Runtime
+from pykokkos.core import Runtime
 from pykokkos.interface import *
 from pykokkos.kokkos_manager import (
     initialize, finalize,
@@ -79,14 +79,6 @@ __array_api_version__ = "2021.12"
 __all__ = ["__array_api_version__"]
 
 runtime_singleton.runtime = Runtime()
-defaults: Optional[CompilationDefaults] = runtime_singleton.runtime.compiler.read_defaults()
-
-if defaults is not None:
-    set_default_space(ExecutionSpace[defaults.space])
-    if defaults.force_uvm:
-        enable_uvm()
-    else:
-        disable_uvm()
 
 def cleanup():
     """

--- a/pykokkos/core/__init__.py
+++ b/pykokkos/core/__init__.py
@@ -1,5 +1,3 @@
-from pykokkos.interface import *
-
 from .compiler import CompilationDefaults, Compiler
 from .keywords import Keywords
 from .runtime import Runtime

--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -118,7 +118,7 @@ class Compiler:
         updated_types: Optional[UpdatedTypes] = None,
         types_signature: Optional[str] = None,
         **kwargs
-    ) -> Optional[PyKokkosMembers]:
+    ) -> PyKokkosMembers:
         """
         Compile an entity object for a single execution space
 

--- a/pykokkos/core/fusion/__init__.py
+++ b/pykokkos/core/fusion/__init__.py
@@ -1,2 +1,2 @@
 from .fuse import fuse_workunit_kwargs_and_params, fuse_workunits
-from .trace import Future, Tracer
+from .trace import Future, Tracer, TracerOperation

--- a/pykokkos/core/fusion/__init__.py
+++ b/pykokkos/core/fusion/__init__.py
@@ -1,1 +1,2 @@
 from .fuse import fuse_workunit_kwargs_and_params, fuse_workunits
+from .trace import Future, Tracer

--- a/pykokkos/core/fusion/access_modes.py
+++ b/pykokkos/core/fusion/access_modes.py
@@ -1,0 +1,53 @@
+import ast
+from enum import auto, Enum
+from typing import Dict, Optional, Set
+
+from pykokkos.core.translators.static import StaticTranslator
+
+
+class AccessMode(Enum):
+    Read = auto()
+    Write = auto()
+    ReadWrite = auto()
+
+
+def get_view_access_modes(AST: ast.FunctionDef, view_args: Set[str]) -> Dict[str, AccessMode]:
+    AST = StaticTranslator.add_parent_refs(AST)
+    access_modes: Dict[str, AccessMode] = {}
+
+    for node in ast.walk(AST):
+        if not isinstance(node, ast.Subscript): # We are only interested in view accesses
+            continue
+
+        if not isinstance(node.value, ast.Name): # Skip type annotations
+            continue
+
+        name: str = node.value.id
+        if name not in view_args:
+            continue
+
+        existing_mode: Optional[AccessMode] = access_modes.get(name)
+        new_mode: AccessMode
+
+        if isinstance(node.ctx, ast.Load):
+            if existing_mode is None:
+                new_mode = AccessMode.Read
+            elif existing_mode is AccessMode.Write:
+                new_mode = AccessMode.ReadWrite
+            else:
+                new_mode = existing_mode
+
+        if isinstance(node.ctx, ast.Store):
+            if existing_mode is None:
+                new_mode = AccessMode.Write
+            elif existing_mode is AccessMode.Read:
+                new_mode = AccessMode.ReadWrite
+            else:
+                new_mode = existing_mode
+
+        if new_mode is AccessMode.Write and isinstance(node.parent, ast.AugAssign):
+            new_mode = AccessMode.ReadWrite
+
+        access_modes[name] = new_mode
+
+    return access_modes

--- a/pykokkos/core/fusion/future.py
+++ b/pykokkos/core/fusion/future.py
@@ -40,7 +40,5 @@ class Future:
         return str(f"Future(value={self.value})")
 
     def flush_trace(self) -> None:
-        if self.value is not None:
-            return
         runtime_singleton.runtime.flush_data(self)
         assert self.value is not None

--- a/pykokkos/core/fusion/future.py
+++ b/pykokkos/core/fusion/future.py
@@ -1,0 +1,46 @@
+from pykokkos.runtime import runtime_singleton
+
+
+class Future:
+    """
+    Delayed reductions and scans return a Future
+    """
+
+    def __init__(self) -> None:
+        self.value = None
+
+    def assign_value(self, value) -> None:
+        self.value = value
+
+    def __add__(self, other):
+        self.flush_trace()
+        return self.value + other
+
+    def __sub__(self, other):
+        self.flush_trace()
+        return self.value - other
+
+    def __mul__(self, other):
+        self.flush_trace()
+        return self.value * other
+
+    def __truediv__(self, other):
+        self.flush_trace()
+        return self.value / other
+
+    def __floordiv__(self, other):
+        self.flush_trace()
+        return self.value // other
+
+    def __str__(self):
+        self.flush_trace()
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        return str(f"Future(value={self.value})")
+
+    def flush_trace(self) -> None:
+        if self.value is not None:
+            return
+        runtime_singleton.runtime.flush_data(self)
+        assert self.value is not None

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -175,6 +175,7 @@ class Tracer:
 
         operation: TracerOperation = self.data_operation[dependency]
         operations: List[TracerOperation] = [operation]
+        del self.operations[operation]
 
         # Ideally, we would not have to do this. By adding an
         # operation to this list, its dependencies should be

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -1,9 +1,10 @@
+import copy
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from types import NoneType
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
-if TYPE_CHECKING:
-    from pykokkos.core.type_inference import UpdatedDecorator, UpdatedTypes 
-from pykokkos.interface import ExecutionPolicy
+from pykokkos.interface import ExecutionPolicy, ViewType
+from pykokkos.runtime import runtime_singleton
 
 
 class Future:
@@ -14,24 +15,57 @@ class Future:
         self.value = value
 
     def __add__(self, other):
-        assert self.value is not None
+        self.flush_trace()
         return self.value + other
 
     def __sub__(self, other):
-        assert self.value is not None
+        self.flush_trace()
         return self.value - other
 
     def __mul__(self, other):
-        assert self.value is not None
+        self.flush_trace()
         return self.value * other
 
+    def __truediv__(self, other):
+        self.flush_trace()
+        return self.value / other
+
+    def __floordiv__(self, other):
+        self.flush_trace()
+        return self.value // other
+
     def __str__(self):
-        assert self.value is not None
+        self.flush_trace()
         return str(self.value)
 
     def __repr__(self) -> str:
+        return str(f"Future(value={self.value})")
+
+    def flush_trace(self) -> None:
+        if self.value is not None:
+            return
+        runtime_singleton.runtime.flush_data(self)
         assert self.value is not None
-        return str(self.value)
+
+
+@dataclass
+class DataDependency:
+    """
+    Represents data + version
+    """
+
+    name: Optional[str] # for debugging purposes
+    data_id: int
+    version: int
+
+    def __hash__(self) -> int:
+        return hash((self.data_id, self.version))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, DataDependency):
+            return False
+
+        return self.data_id == other.data_id and self.version == other.version
 
 
 @dataclass
@@ -40,15 +74,25 @@ class TracerOperation:
     A single operation in a trace
     """
 
+    op_id: int
     future: Optional[Future]
     name: Optional[str]
     policy: ExecutionPolicy
     workunit: Callable[..., None]
     operation: str
-    decorator: UpdatedDecorator
-    types: UpdatedTypes
+    decorator: Any # UpdatedDecorator
+    types: Any # UpdatedTypes
     args: Dict[str, Any]
+    dependencies: Set[DataDependency]
 
+    def __hash__(self) -> int:
+        return self.op_id
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, TracerOperation):
+            return False
+
+        return self.op_id == other.op_id
 
 class Tracer:
     """
@@ -56,7 +100,16 @@ class Tracer:
     """
 
     def __init__(self) -> None:
-        self.operations: List[TracerOperation] = []
+        self.op_id: int = 0
+
+        # This functions as an ordered set
+        self.operations: Dict[TracerOperation, NoneType] = {}
+
+        # Map from each data object id (future or array) to the current version
+        self.data_version: Dict[int, int] = {}
+
+        # Map from data version to tracer operation
+        self.data_operation: Dict[DataDependency, TracerOperation] = {}
 
     def log_operation(
         self,
@@ -65,8 +118,8 @@ class Tracer:
         policy: ExecutionPolicy,
         workunit: Callable[..., None],
         operation: str,
-        updated_decorator: UpdatedDecorator,
-        updated_types: Optional[UpdatedTypes],
+        updated_decorator: Any, # UpdatedDecorator,
+        updated_types: Any, #Optional[UpdatedTypes],
         **kwargs
     ) -> None:
         """
@@ -82,5 +135,72 @@ class Tracer:
         :param initial_value: the initial value of the accumulator
         """
 
-        self.operations.append(
-            TracerOperation(future, name, policy, workunit, operation, updated_decorator, updated_types, dict(kwargs)))
+        dependencies: Set[DataDependency] = set()
+
+        # For now assume each dependency is RW, later on parse the AST
+        for arg, value in kwargs.items():
+            if isinstance(value, (Future, ViewType)):
+                version: int = self.data_version.get(id(value), 0)
+                dependency = DataDependency(arg, id(value), version)
+
+                dependencies.add(dependency)
+                self.data_version[id(value)] = version + 1
+
+        tracer_op = TracerOperation(self.op_id, future, name, policy, workunit, operation, updated_decorator, updated_types, dict(kwargs), dependencies)
+        self.op_id += 1
+
+        for dependency in dependencies:
+            new_dep = copy.deepcopy(dependency)
+            new_dep.version += 1
+            self.data_operation[new_dep] = tracer_op
+
+        if operation in {"reduce", "scan"}:
+            assert future is not None
+            self.data_operation[DataDependency(None, id(future), 0)] = tracer_op
+
+        # Add to the ordered set of operations
+        self.operations[tracer_op] = None
+
+    def get_operations(self, data: Union[Future, ViewType]) -> List[TracerOperation]:
+        """
+        Get all the operations needed to update the data of a future
+        or view and remove them from the trace
+
+        :param future: the future corresponding to the value that needs to be updated
+        :returns: the list of operations to be executed
+        """
+
+        version: int = self.data_version.get(id(data), 0)
+        dependency = DataDependency(None, id(data), version)
+
+        operation: TracerOperation = self.data_operation[dependency]
+        operations: List[TracerOperation] = [operation]
+
+        # Ideally, we would not have to do this. By adding an
+        # operation to this list, its dependencies should be
+        # automatically updated when the operation is executed.
+        # However, since the operations are not executed in Python, we
+        # cannot trigger the flush. We could also potentially iterate
+        # over kwargs prior to invoking a kernel and call
+        # flush_value() for all futures and views. We should implement
+        # both and benchmark them
+        i: int = 0
+        while i < len(operations):
+            current_op = operations[i]
+
+            for dep in current_op.dependencies:
+                if dep not in self.data_operation:
+                    assert dep.version == 0
+                    continue
+
+                dependency_op: TracerOperation = self.data_operation[dep]
+                if dependency_op not in self.operations:
+                    # This means that the dependency was already updated
+                    continue
+
+                operations.append(dependency_op)
+                del self.operations[dependency_op]
+
+            i += 1
+
+        return operations

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -4,48 +4,8 @@ from types import NoneType
 from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 from pykokkos.interface import ExecutionPolicy, ViewType
-from pykokkos.runtime import runtime_singleton
 
-
-class Future:
-    def __init__(self) -> None:
-        self.value = None
-
-    def assign_value(self, value) -> None:
-        self.value = value
-
-    def __add__(self, other):
-        self.flush_trace()
-        return self.value + other
-
-    def __sub__(self, other):
-        self.flush_trace()
-        return self.value - other
-
-    def __mul__(self, other):
-        self.flush_trace()
-        return self.value * other
-
-    def __truediv__(self, other):
-        self.flush_trace()
-        return self.value / other
-
-    def __floordiv__(self, other):
-        self.flush_trace()
-        return self.value // other
-
-    def __str__(self):
-        self.flush_trace()
-        return str(self.value)
-
-    def __repr__(self) -> str:
-        return str(f"Future(value={self.value})")
-
-    def flush_trace(self) -> None:
-        if self.value is not None:
-            return
-        runtime_singleton.runtime.flush_data(self)
-        assert self.value is not None
+from .future import Future
 
 
 @dataclass

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pykokkos.core.type_inference import UpdatedDecorator, UpdatedTypes 
+from pykokkos.interface import ExecutionPolicy
+
+
+class Future:
+    def __init__(self) -> None:
+        self.value = None
+
+    def assign_value(self, value) -> None:
+        self.value = value
+
+    def __add__(self, other):
+        assert self.value is not None
+        return self.value + other
+
+    def __sub__(self, other):
+        assert self.value is not None
+        return self.value - other
+
+    def __mul__(self, other):
+        assert self.value is not None
+        return self.value * other
+
+    def __str__(self):
+        assert self.value is not None
+        return str(self.value)
+
+    def __repr__(self) -> str:
+        assert self.value is not None
+        return str(self.value)
+
+
+@dataclass
+class TracerOperation:
+    """
+    A single operation in a trace
+    """
+
+    future: Optional[Future]
+    name: Optional[str]
+    policy: ExecutionPolicy
+    workunit: Callable[..., None]
+    operation: str
+    decorator: UpdatedDecorator
+    types: UpdatedTypes
+    args: Dict[str, Any]
+
+
+class Tracer:
+    """
+    Holds traces of operations
+    """
+
+    def __init__(self) -> None:
+        self.operations: List[TracerOperation] = []
+
+    def log_operation(
+        self,
+        future: Optional[Future],
+        name: Optional[str],
+        policy: ExecutionPolicy,
+        workunit: Callable[..., None],
+        operation: str,
+        updated_decorator: UpdatedDecorator,
+        updated_types: Optional[UpdatedTypes],
+        **kwargs
+    ) -> None:
+        """
+        Log the workunit and its arguments in the trace
+
+        :param name: the name of the kernel
+        :param policy: the execution policy of the operation
+        :param workunit: the workunit function object
+        :param kwargs: the keyword arguments passed to the workunit
+        :param updated_decorator: Object with decorator specifier information
+        :param updated_types: UpdatedTypes object with type inference information
+        :param operation: the name of the operation "for", "reduce", or "scan"
+        :param initial_value: the initial value of the accumulator
+        """
+
+        self.operations.append(
+            TracerOperation(future, name, policy, workunit, operation, updated_decorator, updated_types, dict(kwargs)))

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -1,6 +1,5 @@
 import ast
 from dataclasses import dataclass
-from types import NoneType
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from pykokkos.core.parsers import Parser, PyKokkosEntity
@@ -71,7 +70,7 @@ class Tracer:
         self.op_id: int = 0
 
         # This functions as an ordered set
-        self.operations: Dict[TracerOperation, NoneType] = {}
+        self.operations: Dict[TracerOperation, None] = {}
 
         # Map from each data object id (future or array) to the current version
         self.data_version: Dict[int, int] = {}

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -40,8 +40,6 @@ class TracerOperation:
     policy: ExecutionPolicy
     workunit: Callable[..., None]
     operation: str
-    decorator: Any # UpdatedDecorator
-    types: Any # UpdatedTypes
     args: Dict[str, Any]
     dependencies: Set[DataDependency]
 
@@ -78,8 +76,6 @@ class Tracer:
         policy: ExecutionPolicy,
         workunit: Callable[..., None],
         operation: str,
-        updated_decorator: Any, # UpdatedDecorator,
-        updated_types: Any, #Optional[UpdatedTypes],
         **kwargs
     ) -> None:
         """
@@ -89,8 +85,6 @@ class Tracer:
         :param policy: the execution policy of the operation
         :param workunit: the workunit function object
         :param kwargs: the keyword arguments passed to the workunit
-        :param updated_decorator: Object with decorator specifier information
-        :param updated_types: UpdatedTypes object with type inference information
         :param operation: the name of the operation "for", "reduce", or "scan"
         :param initial_value: the initial value of the accumulator
         """
@@ -106,7 +100,7 @@ class Tracer:
                 dependencies.add(dependency)
                 self.data_version[id(value)] = version + 1
 
-        tracer_op = TracerOperation(self.op_id, future, name, policy, workunit, operation, updated_decorator, updated_types, dict(kwargs), dependencies)
+        tracer_op = TracerOperation(self.op_id, future, name, policy, workunit, operation, dict(kwargs), dependencies)
         self.op_id += 1
 
         for dependency in dependencies:
@@ -134,6 +128,10 @@ class Tracer:
         dependency = DataDependency(None, id(data), version)
 
         operation: TracerOperation = self.data_operation[dependency]
+        if operation not in self.operations:
+            # This means that the dependency was already updated
+            return []
+
         operations: List[TracerOperation] = [operation]
         del self.operations[operation]
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -187,7 +187,6 @@ class Runtime:
         operations: List[TracerOperation] = self.tracer.get_operations(data)
         while len(operations) > 0:
             op: TracerOperation = operations.pop()
-            print(f"running {op.workunit}")
             op.future.value = self.execute_workunit(op.name, op.policy, op.workunit, op.decorator, op.types, **op.args)
 
     def flush_trace(self) -> None:

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -7,7 +7,7 @@ import sysconfig
 
 import numpy as np
 
-from pykokkos.core.fusion import fuse_workunit_kwargs_and_params, Future, Tracer
+from pykokkos.core.fusion import fuse_workunit_kwargs_and_params, Future, Tracer, TracerOperation
 from pykokkos.core.keywords import Keywords
 from pykokkos.core.translators import PyKokkosMembers
 from pykokkos.core.visitors import visitors_util
@@ -127,9 +127,9 @@ class Runtime:
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)
 
         if "PK_TRACE" in os.environ:
-            f = Future()
-            self.tracer.log_operation(f, name, policy, workunit, operation, **kwargs)
-            return f
+            future = Future()
+            self.tracer.log_operation(future, name, policy, workunit, operation, **kwargs)
+            return future
 
         return self.execute_workunit(name, policy, workunit, operation, **kwargs)
 
@@ -176,7 +176,25 @@ class Runtime:
         module_setup: ModuleSetup = self.get_module_setup(workunit, execution_space, types_signature)
         return self.execute(workunit, module_setup, members, execution_space, policy=policy, name=name, **kwargs)
 
-    def flush_trace(self):
+    def flush_data(self, data: Union[Future, ViewType]) -> None:
+        """
+        Flush the operations needed to get the data of a specific
+        data or view
+
+        :param data: the future or view corresponding to the data that needs to be updated
+        """
+
+        operations: List[TracerOperation] = self.tracer.get_operations(data)
+        while len(operations) > 0:
+            op: TracerOperation = operations.pop()
+            print(f"running {op.workunit}")
+            op.future.value = self.execute_workunit(op.name, op.policy, op.workunit, op.decorator, op.types, **op.args)
+
+    def flush_trace(self) -> None:
+        """
+        Flush all operations saved in the trace
+        """
+
         for op in self.tracer.operations:
             op.future.value = self.execute_workunit(op.name, op.policy, op.workunit, op.decorator, op.types, **op.args)
 
@@ -495,7 +513,7 @@ class Runtime:
         entity: Union[object, Callable[..., None]],
         space: ExecutionSpace,
         types_signature: Optional[str] = None
-        ) -> ModuleSetup:
+    ) -> ModuleSetup:
         """
         Get the compiled module setup information unique to an entity + space
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -451,6 +451,8 @@ class Runtime:
                                np.int32, np.int64, np.uint8, np.uint16, 
                                np.uint32, np.uint64, np.float32, np.double, np.float64):
                 fields[key] = value
+            if isinstance(value, Future):
+                fields[key] = value.value
 
         return fields
 

--- a/pykokkos/core/type_inference/__init__.py
+++ b/pykokkos/core/type_inference/__init__.py
@@ -1,4 +1,3 @@
 from .args_type_inference import (
-    UpdatedTypes, UpdatedDecorator, HandledArgs,
-    handle_args, get_type_str, get_type_info
+    UpdatedTypes, UpdatedDecorator, get_type_str, get_type_info
 )

--- a/pykokkos/core/visitors/kokkosmain_visitor.py
+++ b/pykokkos/core/visitors/kokkosmain_visitor.py
@@ -107,7 +107,7 @@ class KokkosMainVisitor(PyKokkosVisitor):
 
                 else:
                     bin_op_type: str = f"decltype({visitors_util.get_node_name(args[1])})"
-                    cpp_type = cppast.DeclRefExpr(BinSort.get_type(view_type_str, bin_op_type))
+                    cpp_type = cppast.DeclRefExpr(BinSort.get_type(view_type_str, bin_op_type, Keywords.DefaultExecSpace.value))
 
                     binsort_args: List[cppast.DeclRefExpr] = [self.visit(a) for a in args]
                     constructor = cppast.CallExpr(cpp_type, binsort_args)

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -34,7 +34,7 @@ from .hierarchical import (
 )
 from .memory_space import MemorySpace, get_default_memory_space
 from .parallel_dispatch import (
-    execute,
+    execute, flush,
     parallel_for, parallel_reduce, parallel_scan,
 )
 from .random import (

--- a/pykokkos/interface/bin_sort.py
+++ b/pykokkos/interface/bin_sort.py
@@ -1,7 +1,5 @@
 from typing import List, Union
 
-from pykokkos.core.keywords import Keywords
-
 from .views import View
 
 
@@ -53,8 +51,8 @@ class BinSort:
         self.sort_within_bins = sort_within_bins
 
     @staticmethod
-    def get_type(key_view_type: str, bin_op_type: str) -> str:
-        return f"Kokkos::BinSort<{key_view_type},{bin_op_type},{Keywords.DefaultExecSpace.value},int>"
+    def get_type(key_view_type: str, bin_op_type: str, space: str) -> str:
+        return f"Kokkos::BinSort<{key_view_type},{bin_op_type},{space},int>"
 
     def sort(self, values: View) -> None:
         pass

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -95,7 +95,7 @@ def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
 
     handled_args: HandledArgs = handle_args(True, args)
 
-    runtime_singleton.runtime.run_workunit(
+    return runtime_singleton.runtime.run_workunit(
         handled_args.name,
         handled_args.policy,
         handled_args.workunit,

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -61,8 +61,6 @@ def parallel_for(*args, **kwargs) -> None:
         "for",
         **kwargs)
 
-    # workunit_cache[cache_key] = (func, args)
-    func(**args)
 
 def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
     """
@@ -104,8 +102,6 @@ def reduce_body(operation: str, *args, **kwargs) -> Union[float, int]:
         operation,
         **kwargs)
 
-    workunit_cache[cache_key] = (func, args)
-    return func(**args)
 
 def parallel_reduce(*args, **kwargs) -> Union[float, int]:
     """
@@ -153,3 +149,6 @@ def execute(space: ExecutionSpace, workload: object) -> None:
     else:
         runtime_singleton.runtime.run_workload(space, workload)
 
+
+def flush():
+    runtime_singleton.runtime.flush_trace()

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -1,15 +1,92 @@
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import numpy as np
 
 from pykokkos.runtime import runtime_singleton
 import pykokkos.kokkos_manager as km
-from pykokkos.core.type_inference import HandledArgs, handle_args
 
-from .execution_policy import ExecutionPolicy
+from .execution_policy import ExecutionPolicy, RangePolicy
 from .execution_space import ExecutionSpace
+from .views import ViewType
 
 workunit_cache: Dict[int, Callable] = {}
+
+
+@dataclass
+class HandledArgs:
+    """
+    Class for holding the arguments passed to parallel_* functions
+    """
+
+    name: Optional[str]
+    policy: ExecutionPolicy
+    workunit: Callable
+    view: Optional[ViewType]
+    initial_value: Union[int, float]
+
+
+def handle_args(is_for: bool, *args) -> HandledArgs:
+    """
+    Handle the *args passed to parallel_* functions
+
+    :param is_for: whether the arguments belong to a parallel_for call
+    :param *args: the list of arguments being checked
+    :returns: a HandledArgs object containing the passed arguments
+    """
+
+    unpacked: Tuple = tuple(*args)
+
+    name: Optional[str] = None
+    policy: Union[ExecutionPolicy, int]
+    workunit: Callable
+    view: Optional[ViewType] = None
+    initial_value: Union[int, float] = 0
+
+
+    if len(unpacked) == 2:
+        policy = unpacked[0]
+        workunit = unpacked[1]
+
+    elif len(unpacked) == 3:
+        if isinstance(unpacked[0], str):
+            name = unpacked[0]
+            policy = unpacked[1]
+            workunit = unpacked[2]
+        elif is_for and isinstance(unpacked[2], ViewType):
+            policy = unpacked[0]
+            workunit = unpacked[1]
+            view = unpacked[2]
+        elif isinstance(unpacked[2], (int, float)):
+            policy = unpacked[0]
+            workunit = unpacked[1]
+            initial_value = unpacked[2]
+        else:
+            raise TypeError(f"ERROR: wrong arguments {unpacked}")
+
+    elif len(unpacked) == 4:
+        if isinstance(unpacked[0], str):
+            name = unpacked[0]
+            policy = unpacked[1]
+            workunit = unpacked[2]
+
+            if is_for and isinstance(unpacked[3], ViewType):
+                view = unpacked[3]
+            elif isinstance(unpacked[3], (int, float)):
+                initial_value = unpacked[3]
+            else:
+                raise TypeError(f"ERROR: wrong arguments {unpacked}")
+        else:
+            raise TypeError(f"ERROR: wrong arguments {unpacked}")
+
+    else:
+        raise ValueError(f"ERROR: incorrect number of arguments {len(unpacked)}")
+
+    if isinstance(policy, (int, np.integer)):
+        policy = RangePolicy(ExecutionSpace.Default, 0, int(policy))
+
+    return HandledArgs(name, policy, workunit, view, initial_value)
 
 
 def check_policy(policy: Any) -> None:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -172,6 +172,9 @@ class ViewType:
         :returns: an iterator over the data
         """
 
+        if "PK_TRACE" in os.environ:
+            runtime_singleton.runtime.flush_data(self)
+
         if self.data.ndim > 0:
             return (n for n in self.data)
         else:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import ctypes
 import math
 from enum import Enum
+import os
 import sys
 from types import ModuleType
 from typing import (
@@ -14,6 +15,7 @@ import numpy as np
 import pykokkos as pk
 from pykokkos.bindings import kokkos
 import pykokkos.kokkos_manager as km
+from pykokkos.runtime import runtime_singleton
 
 from .data_types import (
     DataType, DataTypeClass,
@@ -113,6 +115,9 @@ class ViewType:
         :returns: a primitive type value if key is an int, a Subview otherwise
         """
 
+        if "PK_TRACE" in os.environ:
+            runtime_singleton.runtime.flush_data(self)
+
         if self.shape == () and key == 0:
             return self.data
 
@@ -180,6 +185,9 @@ class ViewType:
         :returns: the string representation of the data
         """
 
+        if "PK_TRACE" in os.environ:
+            runtime_singleton.runtime.flush_data(self)
+
         return str(self.data)
 
     def __deepcopy__(self, memo):
@@ -191,6 +199,9 @@ class ViewType:
 
 
     def _scalarfunc(self, func):
+        if "PK_TRACE" in os.environ:
+            runtime_singleton.runtime.flush_data(self)
+
         # based on approach used in
         # numpy/lib/user_array.py for
         # handling scalar conversions


### PR DESCRIPTION
Implement delayed execution in PyKokkos. This is enabled when the environment variable `PK_TRACE` is set. Delayed operations are executed either through `pk.flush()` or when the data that depends on those operations is accessed. This data can be either a Future returned from a reduction or scan or a View.