### PR TITLE
Add support for the pass statement in trivial cases (empty body)

### DIFF
--- a/pk
+++ b/pk
@@ -48,14 +48,21 @@ function pk_docker_pull() {
 
 function _pk_cmd() {
         local -r name="${1}"
+        [ $# -lt 1 ] && return 1
+        shift 1
+
+        [ -z "${name}" ] && \
+                { echo "no name provided"; return 1; }
 
         ( cd "${CHOME}/pykokkos"
           export PYTHONPATH=pykokkos:$PYTHONPATH
-          python "${name}" )
+          python "${name}" "$@" )
 }
 
 function pk_example() {
         local -r name="${1}"
+        [ $# -lt 1 ] && return 1
+        shift 1
 
         [ -z "${name}" ] && \
                 { echo "no name provided (e.g., examples/kokkos-tutorials/workload/01.py)"; return 1; }
@@ -67,11 +74,12 @@ function pk_example() {
                --volume $(pwd):"${CHOME}/pykokkos" \
                --user pk:$(id -g) \
                "${PROJECT}" \
-               "${CHOME}/pykokkos/pk" "_pk_cmd" "${name}"
+               "${CHOME}/pykokkos/pk" "_pk_cmd" "${name}" \
+               "$@"
 }
 
 function pk_tests() {
-        pk_example "runtests.py"
+        pk_example "runtests.py" "$@"
 }
 
 "$@"

--- a/pykokkos/core/cppast/serializer.py
+++ b/pykokkos/core/cppast/serializer.py
@@ -300,7 +300,7 @@ class Serializer:
         return self.serialize(node.decl) + ";"
 
     def serialize_EmptyStmt(self, node: EmptyStmt) -> str:
-        return ""
+        return "{}"
 
     def serialize_ForStmt(self, node: ForStmt) -> str:
         init: str = self.serialize(node.init)

--- a/tests/test_AST_translator.py
+++ b/tests/test_AST_translator.py
@@ -111,6 +111,10 @@ class ASTTestReduceFunctor:
             x += 1
 
     @pk.workunit
+    def pass_stmt(self, tid: int) -> None:
+        pass
+
+    @pk.workunit
     def call(self, tid: int, acc: pk.Acc[pk.double]) -> None:
         pk.printf("Testing printf: %d\n", self.i_1)
         acc += abs(- self.i_1)
@@ -268,6 +272,9 @@ class TestASTTranslator(unittest.TestCase):
         result: int = pk.parallel_reduce(self.range_policy, self.functor.while_stmt)
 
         self.assertEqual(expected_result, result)
+
+    def test_pass(self):
+        pk.parallel_for(self.range_policy, self.functor.pass_stmt)
 
     def test_call(self):
         expected_result: int = self.threads * abs(- self.i_1)


### PR DESCRIPTION
This PR replaces the `pass` statement with `{}` rather than "". As a result, we do not observe errors when we have a surrounding block that is empty, e.g., an empty workunit with only `pass` in the body.

Also, a simple test for the pass statement is added.

Finally, the `pk` script is slightly extended to enable passing command line arguments to the script being executed, e.g., runtests.py (which enables selecting tests).

This PR addressing the issue: https://github.com/kokkos/pykokkos/issues/232
