### PR TITLE
doc: Revising README to focus on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # PyKokkos
 
-PyKokkos is a framework for writing performance portable kernels in
-Python. You can think of PyKokkos as a performance portable Numba.  In
-background, PyKokkos translates type-annotated Python code into C++
-[Kokkos](https://github.com/kokkos/kokkos/) and automatically
-generating bindings for the translated C++ code.
+PyKokkos is a framework for writing high-performance Python code
+similar to Numba. In contrast to Numba, PyKokkos kernels are primarily
+parallel and are also performance portable, meaning that they can run
+efficiently on different hardware (CPUs, NVIDIA GPUs, and AMD GPUs)
+with no changes required. In the background, PyKokkos translates
+kernels designated by the user into C++
+[Kokkos](https://github.com/kokkos/kokkos) and automatically
+generates language bindings to run the generated code.
 
 We recommend using Docker for running code and developing (see
 [Developing using Docker](#developing-using-docker)), but detailed
@@ -140,7 +143,7 @@ def hello(i: int):
 
 Kernels definitions are marked with the `@pk.workunit` decorator. Each
 workunit requires an integer argument which represents the thread ID.
-This argument has to be type annotated using `int`.
+This argument can optionally be type annotated (`int` in the example).
 
 This workunit can be called using the `parallel_for` function:
 
@@ -185,8 +188,8 @@ if __name__ == "__main__":
     pk.parallel_for(n, add, v=v, x=1)
 ```
 
-As with the thread ID, arguments must be type annotated. They can the
-be passed via `parallel_for` using keyword arguments.
+As with the thread ID, arguments can be type annotated. They have to
+be passed to `parallel_for` using keyword arguments.
 
 ### Other Examples
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,58 @@
 # PyKokkos
 
 PyKokkos is a framework for writing performance portable kernels in
-Python. At a high-level, PyKokkos translates type-annotated Python
-code into C++ [Kokkos](https://github.com/kokkos/kokkos/) and
-automatically generating bindings for the translated C++ code.
-PyKokkos also makes use of [Python
-bindings](https://github.com/kokkos/kokkos-python) for constructing
-Kokkos Views.
+Python. You can think of PyKokkos as a performance portable Numba.  In
+background, PyKokkos translates type-annotated Python code into C++
+[Kokkos](https://github.com/kokkos/kokkos/) and automatically
+generating bindings for the translated C++ code.
 
-## Installation
+We recommend using Docker for running code and developing (see
+[Developing using Docker](#developing-using-docker)), but detailed
+installation instructions are available (see [Native
+Installation](#native-installation)).
+
+
+## Developing Using Docker
+
+You can use our Docker image to develop pykokkos and run examples.  We
+recommend using the `pk` script for interacting with the image.
+
+To run an example in the image, you can execute the following command:
+
+```
+./pk pk_example examples/kokkos-tutorials/workload/01.py
+```
+
+The command above will pull the image, run a container, include this
+repository as a volume, and run the example on the given path.
+
+If you would like to run another example, you simply change the path
+(the last argument in the command above).
+
+Note that the example you are running should be in this repository.
+If you would like to run from another directory you will need to
+include those as a volume; take a look at the `pk` script in that case.
+
+### Design Decision
+
+At the moment, we decided to include this repository as a volume when
+starting a container, which enables the development workflow. Namely,
+the `pk` script will include the current local version of this
+repository, which means that any local modifications (e.g., a change
+in `parallel_dispatch.py`) will be used in the subsequent runs of the
+`pk` script.  In the future, we might separate a user and development
+workflows.
+
+### Limitations
+
+One, as described above, you would need to modify the `pk` script if
+you are running examples that are not part of this repository.
+
+Two, if your code requires dependencies (e.g., python libraries not
+already included in the image), you would need to build your own image.
+
+
+## Native Installation
 
 Clone [pykokkos-base](https://github.com/kokkos/pykokkos-base) and
 create a conda environment:
@@ -78,44 +122,6 @@ python runtests.py
 
 Please open an issue for help with installation.
 
-## Running / Developing using Docker
-
-You can use our Docker image to develop pykokkos and run examples.  We
-recommend using the `pk` script for interacting with the image.
-
-To run an example in the image, you can execute the following command:
-
-```
-./pk pk_example examples/kokkos-tutorials/workload/01.py
-```
-
-The command above will pull the image, run a container, include this
-repository as a volume, and run the example on the given path.
-
-If you would like to run another example, you simply change the path
-(the last argument in the command above).
-
-Note that the example you are running should be in this repository.
-If you would like to run from another directory you will need to
-include those as a volume; take a look at the `pk` script in that case.
-
-### Design Decision
-
-At the moment, we decided to include this repository as a volume when
-starting a container, which enables the development workflow. Namely,
-the `pk` script will include the current local version of this
-repository, which means that any local modifications (e.g., a change
-in `parallel_dispatch.py`) will be used in the subsequent runs of the
-`pk` script.  In the future, we might separate a user and development
-workflows.
-
-### Limitations
-
-One, as described above, you would need to modify the `pk` script if
-you are running examples that are not part of this repository.
-
-Two, if your code requires dependencies (e.g., python libraries not
-already included in the image), you would need to build your own image.
 
 ## Examples
 
@@ -182,11 +188,10 @@ if __name__ == "__main__":
 As with the thread ID, arguments must be type annotated. They can the
 be passed via `parallel_for` using keyword arguments.
 
-
 ### Other Examples
 
-The following table shows a list of other PyKokkos examples, as well
-as their corresponding C++ Kokkos implementations:
+The following table lists several other PyKokkos examples, as well as
+their corresponding C++ Kokkos implementations:
 
 | Example  | | |
 | -------- | - | - |
@@ -200,6 +205,7 @@ as their corresponding C++ Kokkos implementations:
 | stencil | [PyKokkos](https://github.com/kokkos/pykokkos/blob/main/examples/ParRes/workload/stencil.py) | [Kokkos](https://github.com/ParRes/Kernels/blob/default/Cxx11/stencil-kokkos.cc) |
 | transpose | [PyKokkos](https://github.com/kokkos/pykokkos/blob/main/examples/ParRes/workload/transpose.py) | [Kokkos](https://github.com/ParRes/Kernels/blob/default/Cxx11/transpose-kokkos.cc) |
 | ExaMiniMD | [PyKokkos](https://github.com/kokkos/pykokkos/tree/main/examples/ExaMiniMD) | [Kokkos](https://github.com/ECP-copa/ExaMiniMD) |
+
 
 ## Citation
 
@@ -216,7 +222,8 @@ research paper:
 }
 ```
 
-### Acknowledgments
+
+## Acknowledgments
 
 This project is partially funded by the U.S. Department of Energy,
 National Nuclear Security Administration under Award Number

--- a/pk
+++ b/pk
@@ -2,7 +2,7 @@
 #
 # Script to support using pykokkos docker with the pykokkos repo.
 #
-# The docker image we includes:
+# The docker image includes:
 # * pykokkos-base
 # * kokkos
 #


### PR DESCRIPTION
This PR makes only minor changes to the documentation to emphasize the use of Docker and modifies the opening paragraph to detach from implementation details.