### PR TITLE
Fusion: add new 'naive' fusion strategy

### DIFF
--- a/pykokkos/core/fusion/fuse.py
+++ b/pykokkos/core/fusion/fuse.py
@@ -1,7 +1,6 @@
 import ast
-import inspect
 import os
-from typing import Any, Callable, Dict, List, Set, Tuple, Union
+from typing import Any, Dict, List, Set, Tuple, Union
 
 def get_node_name(node: Union[ast.Attribute, ast.Name]) -> str:
     """

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -115,7 +115,7 @@ class ViewType:
         :returns: a primitive type value if key is an int, a Subview otherwise
         """
 
-        if "PK_TRACE" in os.environ:
+        if "PK_FUSION" in os.environ:
             runtime_singleton.runtime.flush_data(self)
 
         if self.shape == () and key == 0:
@@ -172,7 +172,7 @@ class ViewType:
         :returns: an iterator over the data
         """
 
-        if "PK_TRACE" in os.environ:
+        if "PK_FUSION" in os.environ:
             runtime_singleton.runtime.flush_data(self)
 
         if self.data.ndim > 0:
@@ -188,7 +188,7 @@ class ViewType:
         :returns: the string representation of the data
         """
 
-        if "PK_TRACE" in os.environ:
+        if "PK_FUSION" in os.environ:
             runtime_singleton.runtime.flush_data(self)
 
         return str(self.data)
@@ -202,7 +202,7 @@ class ViewType:
 
 
     def _scalarfunc(self, func):
-        if "PK_TRACE" in os.environ:
+        if "PK_FUSION" in os.environ:
             runtime_singleton.runtime.flush_data(self)
 
         # based on approach used in


### PR DESCRIPTION
Add a new 'naive' fusion strategy which fuses all consecutive `parallel_for` workunits. Reductions and scans are not fused for now. Also replace `PK_TRACE` environment variable with `PK_FUSION`, which can be set to "trace" for only delaying execution (but not actually fusing) or "naive" to delay execution and fuse using the previously mentioned strategy.