### PR TITLE
doc: Initial documentation for PyKokkos (Sphinx format)

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,4 @@
+
+_build/
+_static/
+_templates/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,57 @@
+
+Concepts
+========
+
+On this page, we introduce the key PyKokkos concepts.  We will use the
+following example to illustrate the key concepts.
+
+.. code-block:: python
+
+   import pykokkos as pk
+
+   @pk.workunit
+   def hello(i: int):
+       pk.printf("Hello, World! from i = %d\n", i)
+    
+   def main():
+       pk.parallel_for(10, hello)
+    
+   main()
+
+* **Pattern** specifies the structure of computation (e.g.,
+  ``parallel_for``)
+* **Policy** specifies the way computations are executed (e.g., ``10``
+  parallel units of work)
+* **Work Unit** is a function that performs each unit of work (e.g.,
+  ``hello``)
+
+Execution of a Pattern creates `work`. In the example above, there
+will be 10 `units of work`, such that each unit executes the ``hello``
+function. `Index`, which is the first argument of the Work Unit,
+identifies a unique unit of work. PyKokkos maps work to execution
+resources.
+
+.. note::
+
+   Ordering of execution of units of work is not guaranteed by the
+   runtime.
+
+The three key concepts are closely intertwined.
+
+Kokkos
+------
+
+.. note::
+
+   This section might be of interest only to those familiar with Kokkos.
+
+Unlike in Kokkos, we do not use the term "Computational Body" (but
+rather "Work Unit"), because code for any work is always in a separate
+function. Due to the limitation of Python lambdas, there are no
+multiple ways like in `Kokkos
+<https://kokkos.github.io/kokkos-core-wiki/ProgrammingGuide/ParallelDispatch.html#should-i-use-a-functor-or-a-lambda>`_
+to write computational bodies.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,30 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'pykokkos'
+copyright = '2024, PyKokkos Team'
+author = 'PyKokkos Team'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx_rtd_theme'
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+#html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
+html_static_path = ['_static']

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,51 @@
+
+Using Docker
+============
+
+You can use the PyKokkos Docker image to develop PyKokkos itself, as
+well as develop and run applications.  We recommend using the ``pk``
+script for interacting with the image and containers.
+
+To run an application in a container, you can execute the following
+command:
+
+.. code-block:: bash
+
+   ./pk pk_example examples/kokkos-tutorials/workload/01.py
+
+The command above will pull the image from the Docker Hub, run a
+container, include this repository as a volume, and run the example
+application from the given path.
+
+If you would like to run another example application, you can simply
+change the path (the last argument in the command above).
+
+Note that code you are running should be in the PyKokkos repository.
+If you would like to run from another directory you will need to
+include the directory as a volume; take a look at the ``pk`` script in
+that case.
+
+Design Decision
+---------------
+
+At the moment, we decided to include the PyKokkos repository as a
+volume when starting a container, which enables the development
+workflow. Namely, the ``pk`` script will include the current local
+version of this repository, which means that any local modifications
+(e.g., a change in ``parallel_dispatch.py``) will be used in the
+subsequent runs of the ``pk`` script. In the future, we might separate
+user and development workflows.
+
+Limitations
+-----------
+
+One, as described above, you would need to modify the ``pk`` script if
+you are running code that is not part of this repository.
+
+Two, if your code requires dependencies (e.g., python libraries not
+already included in the image), you would need to install it
+(temporarily) in the container or build your own image.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,61 @@
+
+PyKokkos's Documentation
+========================
+
+PyKokkos is a framework for writing high-performance Python code
+similar to Numba. In contrast to Numba, PyKokkos kernels are primarily
+parallel and are also performance portable, meaning that they can run
+efficiently on different hardware (CPUs, NVIDIA GPUs, and AMD GPUs)
+with no changes required.
+
+PyKokkos is open source and available on `GitHub
+<https://github.com/kokkos/pykokkos>`_.
+
+Below is a quick example that uses PyKokkos.
+
+.. code-block:: python
+
+   import pykokkos as pk
+
+   @pk.workunit
+   def hello(i: int):
+       pk.printf("Hello, World! from i = %d\n", i)
+
+   def main():
+       pk.parallel_for(10, hello)
+
+   main()
+
+Kokkos
+------
+
+In the background, PyKokkos translates kernels designated by the user
+into C++ `Kokkos <https://github.com/kokkos/kokkos>`_ and
+automatically generates language bindings to run the generated code.
+
+.. note::
+
+   Knowing Kokkos is not necessary for using PyKokkos.
+
+On each page of this documentation, we will have a section `Kokkos` to
+discuss similarities between Kokkos and PyKokkos. We believe that the
+`Kokkos` section will be primarily of interest to those already
+familiar with the Kokkos framework.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   docker
+   concepts
+   patterns
+   policies
+   work-units
+
+..
+    Indices and tables
+    ==================
+
+    * :ref:`genindex`
+    * :ref:`modindex`
+    * :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -26,8 +26,8 @@ following signature:
 * **label** is an optional string value helpful for debugging and
   profiling
 * **policy** specifies the way computations are executed (execution
-  place and number of workunits to run in parallel). In its simplies
-  form, policy is an interger value that specifies a range of
+  place and number of work units to run in parallel). In its simplest
+  form, policy is an integer value that specifies a range of
   values. More details about policies is provided in a separate page
   (:doc:`policies`)
 * **workunit** is the name of the ``@pk.workunit`` function that
@@ -91,8 +91,8 @@ signature:
 * **label** is an optional string value helpful for debugging and
   profiling
 * **policy** specifies the way computations are executed (execution
-  place and number of workunits to run in parallel). In its simplies
-  form, policy is an interger value that specifies a range of
+  place and number of workunits to run in parallel). In its simplest
+  form, policy is an integer value that specifies a range of
   values. More details about policies is provided in a separate page
   (:doc:`policies`)
 * **workunit** is the name of the ``@pk.workunit`` function that
@@ -145,8 +145,8 @@ intermediate results.  The pattern is available as a function in the
 * **label** is an optional string value helpful for debugging and
   profiling
 * **policy** specifies the way computations are executed (execution
-  place and number of workunits to run in parallel). In its simplies
-  form, policy is an interger value that specifies a range of
+  place and number of workunits to run in parallel). In its simplest
+  form, policy is an integer value that specifies a range of
   values. More details about policies is provided in a separate page
   (:doc:`policies`)
 * **workunit** is the name of the ``@pk.workunit`` function that

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -1,0 +1,194 @@
+
+Patterns
+========
+
+Pattern is the first key concept in PyKokkos (:doc:`concepts`).
+Patterns specify the structure of computation.  There are three key
+patterns available in PyKokkos:
+
+* ``parallel_for``, which is also known as a ``map`` operation in
+  other frameworks/languages
+* ``parallel_reduce``, which is also known as a ``fold`` operation in
+  other frameworks/languages
+* ``parallel_scan``, which implements a prefix scan
+
+Parallel for
+------------
+
+The most commonly used pattern is ``parallel_for``.  The pattern is
+available as a function in the ``pykokkos`` library and has the
+following signature:
+
+.. code-block:: python
+
+   parallel_for([label], policy, workunit, [keyword arguments])
+
+* **label** is an optional string value helpful for debugging and
+  profiling
+* **policy** specifies the way computations are executed (execution
+  place and number of workunits to run in parallel). In its simplies
+  form, policy is an interger value that specifies a range of
+  values. More details about policies is provided in a separate page
+  (:doc:`policies`)
+* **workunit** is the name of the ``@pk.workunit`` function that
+  performs one unit of work
+* **arguments** are keyword arguments passed to the workunit
+
+Based on the policy, the ``parallel_for`` will execute a number of
+work units in parallel. Each work unit is executed independently and
+there are no guarantees about the execution order. At the same time,
+any number of work units might be running in parallel or they might be
+executed sequentially if the runtime determines that such an execution
+would be beneficial for the overall performance.
+
+Below is an example to illustrate the ``parallel_for`` pattern.
+
+.. code-block:: python
+
+   import pykokkos as pk
+   
+   @pk.workunit
+   def hello(i: int):
+       pk.printf("Hello, World! from i = %d\n", i)
+   
+   def main():
+       pk.parallel_for(10, hello)
+   
+   main()
+
+In this example, the policy is simply an integer value (``10``) that
+specifies a range (``0..9``) of unique ids for work units to be
+spawned (one work unit for one id).  Here is the output for the
+example:
+
+.. code-block:: bash
+
+   Hello, World! from i = 0
+   Hello, World! from i = 8
+   Hello, World! from i = 4
+   Hello, World! from i = 1
+   Hello, World! from i = 9
+   Hello, World! from i = 5
+   Hello, World! from i = 6
+   Hello, World! from i = 2
+   Hello, World! from i = 3
+   Hello, World! from i = 7
+
+Parallel reduce
+---------------
+
+The pattern ``parallel_reduce`` implements a reduction. This pattern
+is similar in many ways to ``parallel_for`` except that each work unit
+produces a value, and all the values are eventually accumulated into a
+single value (known as an accumulator).  This pattern is available as
+a function in the ``pykokkos`` library and has the following
+signature:
+
+.. code-block:: python
+
+   parallel_reduce([label], policy, workunit, [keyword arguments])
+
+* **label** is an optional string value helpful for debugging and
+  profiling
+* **policy** specifies the way computations are executed (execution
+  place and number of workunits to run in parallel). In its simplies
+  form, policy is an interger value that specifies a range of
+  values. More details about policies is provided in a separate page
+  (:doc:`policies`)
+* **workunit** is the name of the ``@pk.workunit`` function that
+  performs one unit of work
+* **arguments** are keyword arguments passed to the workunit
+
+Based on the policy, ``parallel_reduce`` runs a number of work units.
+Each work unit receives `two` arguments in addition to the specified
+keyword arguments: (1) unique id of the work unit, and (2) an
+accumulator.
+
+Below is an example to illustrate the ``parallel_reduce`` pattern:
+
+.. code-block:: python
+
+   import pykokkos as pk
+   import numpy as np
+   
+   @pk.workunit
+   def work(wid, acc, a):
+       acc += a[wid]
+   
+   def main():
+       N = 10
+       a = np.random.randint(100, size=(N))
+       print(a)
+       total = pk.parallel_reduce("work", N, work, a=a)
+       print(total)
+   
+   main()
+
+In the example, we run ``N`` (which is set to ``10``) work units to
+compute the sum of all elements in a numpy array (``a``).  Note that
+the first two arguments to the workunit (``wid`` which is a unique
+identifier of a work unit, and ``acc`` which is an accumulator) are
+provided at runtime by the framework.
+
+Parallel scan
+-------------
+
+The pattern ``parallel_scan`` implements a prefix scan.  This pattern
+is very much like ``parallel_reduce``, but it also stores all
+intermediate results.  The pattern is available as a function in the
+``pykokkos`` library and has the following signature:
+
+.. code-block:: python
+
+   parallel_scan([label], policy, workunit, [keyword arguments])
+
+* **label** is an optional string value helpful for debugging and
+  profiling
+* **policy** specifies the way computations are executed (execution
+  place and number of workunits to run in parallel). In its simplies
+  form, policy is an interger value that specifies a range of
+  values. More details about policies is provided in a separate page
+  (:doc:`policies`)
+* **workunit** is the name of the ``@pk.workunit`` function that
+  performs one unit of work
+* **arguments** are keyword arguments passed to the workunit
+
+As before, based on the policy, ``parallel_scan`` runs a number of
+units of work. Each unit of work receives `three` arguments in
+addition to the given keyword arguments: (1) unique id of the unit of
+work, (2) an accumulator, and (3) a boolean flag to indicate if the
+scan for the current unit of work is complete.
+
+Below is an example to illustrate the ``parallel_scan`` pattern:
+
+.. code-block:: python
+
+   import pykokkos as pk
+   import numpy as np
+   
+   @pk.workunit
+   def work(wid, acc, final, a):
+       acc += a[wid]
+       if final:
+           a[wid] = acc
+   
+   def main():
+       N = 10
+       a = np.random.randint(100, size=(N))
+       print(a)
+   
+       pk.parallel_scan("work", N, work, a=a)
+       print(a)
+   
+   main()
+
+The output for the example above for a single run is:
+
+.. code-block:: bash
+
+   [59 60 48 65 41 22 64 59 91 24]
+   [ 59 119 167 232 273 295 359 418 509 533]
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -3,7 +3,7 @@ Policies
 ========
 
 Policy is the second key concept in PyKokkos (:doc:`concepts`).  Each
-pattern (:doc:`patterns`) accept a policy as an argument. A policy
+pattern (:doc:`patterns`) accepts a policy as an argument. A policy
 specifies the way computation is executed (place and number of units
 of work). In this document, we will use the ``parallel_for`` pattern
 for illustrations, but similar reasoning applies to other patterns.

--- a/docs/policies.rst
+++ b/docs/policies.rst
@@ -1,0 +1,69 @@
+
+Policies
+========
+
+Policy is the second key concept in PyKokkos (:doc:`concepts`).  Each
+pattern (:doc:`patterns`) accept a policy as an argument. A policy
+specifies the way computation is executed (place and number of units
+of work). In this document, we will use the ``parallel_for`` pattern
+for illustrations, but similar reasoning applies to other patterns.
+
+RangePolicy
+-----------
+
+This is the simplest policy, which specifies unique ids for units of
+work as a 1-D range of values.  We can create an instance of
+``RangePolicy`` using the following function from the library:
+
+.. code-block:: python
+
+   pk.RangePolicy([ExecutionPlace], begin_value, end_value)
+
+(We discuss ``ExecutionPlace`` on a separate page.)
+
+We can use an range policy like so:
+
+.. code-block:: python
+
+   parallel_for("work", pk.RangePolicy(0, N), work, kwargs_for_work)
+
+This is equivalent to a simple case we have seen on other pages of
+this documentation:
+
+.. code-block:: python
+
+   parallel_for("work", N, work, kwargs_for_work)
+
+Below is a complete example:
+
+.. code-block:: python
+
+    import pykokkos as pk
+    import numpy as np
+    
+    @pk.workunit
+    def work(wid, a):
+        a[wid] += 1
+    
+    def main():
+        N = 10
+        a = np.random.randint(100, size=(N))
+        print(a)
+    
+        pk.parallel_for("work", pk.RangePolicy(0, N), work, a=a)
+        # OR
+        # pk.parallel_for("work", N, work, a=a)
+        print(a)
+    
+    main()
+
+An example output is shown below:
+
+.. code-block:: bash
+
+   [68 30 75 59  0 25 54 80 36 62]
+   [69 31 76 60  1 26 55 81 37 63]
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/docs/work-units.rst
+++ b/docs/work-units.rst
@@ -1,0 +1,73 @@
+
+Work Units
+==========
+
+Work units are the third key concept in PyKokkos
+(:doc:`concepts`). PyKokkos work units are specified as one of the
+arguments to patterns (:doc:`patterns`). Each work unit is a Python
+function decorated with ``@pk.workunit``. At the time a pattern is
+executed (e.g., ``parallel_for``), the work unit function is invoked
+for each unique id depending on the policy used.
+
+.. note::
+
+   PyKokkos work units are written in a subset of Python. These
+   functions are translated to C++ and compiled to various target
+   architectures. Thus, work units should be lightweight and free from
+   use of various Python libraries.
+
+Signatures
+----------
+
+Depending on the pattern used to invoke a work unit (e.g.,
+``parallel_for``), the signature of the work unit function differs.
+
+In case of ``parallel_for``, the work unit function is required to
+accept, as the first argument, unique id for one unit of work.
+
+.. code-block:: python
+
+   @pk.workunit
+   def work(wid, [keyword arguments])
+
+In case of ``parallel_scan``, the work unit function is required to
+accept two arguments: (1) unique id for one unit of work, and (2) an
+accumulator.
+
+.. code-block:: python
+
+   @pk.workunit
+   def work(wid, acc, [keyword arguments])
+
+Finally, in case of ``parallel_scan``, the work unit function is
+requires to accept three arguments: (1) unique id for one unit of
+work, (2) an accumulator, and (3) a boolean flag to indicate if the
+scan for that unique id is complete.
+
+.. code-block:: python
+
+   @pk.workunit
+   def work(wid, acc, final, [keyword arguments])
+
+Keyword Arguments
+-----------------
+
+Each work unit function can accept an arbitrary number of arguments
+after those required in the signature.  At the time of a pattern
+execution, the arguments have to be given as keyword arguments.
+
+Type Annotations
+----------------
+
+Type annotations for the arguments are optional, but recommended. We
+use type annotations heavily in the examples in the PyKokkos
+repository.
+
+.. note::
+
+   Type annotations for variables defined inside a work unit are
+   currently required.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:


### PR DESCRIPTION
This PR introduces documentation pages for PyKokkos.

The documentation covers the key concepts: patterns, policies, work units. Also, it covers the docker instructions.

Current limitations: there are still policies that are not described, as well as execution spaces. Will be a separate PR. There will also be a separate PR to make this into GitHub pages.