### PR TITLE
versions: Update Python version that we use in CI and drop 3.8 support

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -197,11 +197,7 @@ def get_type(annotation: Union[ast.Attribute, ast.Name, ast.Subscript], pk_impor
 
     if isinstance(annotation, ast.Index):
         # ast.Index has been deprecated since Python 3.9;
-        # this module attempts to shim around it, but we're
-        # still getting issues in gh-181 with Python 3.8
-
-        # we should probably drop support for Python 3.8 soon anyway
-        # per NEP29, but for now we attempt to handle ast.Index
+        # this module attempts to shim around it.
 
         # should convert to ast.Name:
         annotation = annotation.value


### PR DESCRIPTION
This PR moves us to a newer version of Python in CI (the latest one we support) and also drops support for 3.8 (as per gh-182).