### PR TITLE
Fix Debug execution space crashing

### DIFF
--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -122,9 +122,7 @@ class Runtime:
         :returns: the result of the operation (None for parallel_for)
         """
 
-        execution_space: ExecutionSpace = policy.space.space
-
-        if self.is_debug(execution_space):
+        if self.is_debug(policy.space):
             if operation is None:
                 raise RuntimeError("ERROR: operation cannot be None for Debug")
             return run_workunit_debug(policy, workunit, operation, initial_value, **kwargs)

--- a/pykokkos/interface/execution_policy.py
+++ b/pykokkos/interface/execution_policy.py
@@ -56,7 +56,9 @@ class RangePolicy(ExecutionPolicy):
         if isinstance(space, ExecutionSpace):
             if space is ExecutionSpace.Default:
                 space = km.get_default_space()
-            space = km.get_execution_space_instance(space)
+
+            if space is not ExecutionSpace.Debug:
+                space = km.get_execution_space_instance(space)
 
         elif not isinstance(space, ExecutionSpaceInstance):
             raise TypeError(f"Invalid space argument {space}")


### PR DESCRIPTION
This was caused by the recent introduction of execution space instances (which is not applicable to the Debug execution space). This PR fixes the crash by adding checks for Debug as necessary.