### PR TITLE
Fusion: extract access mode of views passed to functions and fix issue with fusing unnamed workunits

### DIFF
--- a/pykokkos/core/fusion/access_modes.py
+++ b/pykokkos/core/fusion/access_modes.py
@@ -16,6 +16,15 @@ def get_view_access_modes(AST: ast.FunctionDef, view_args: Set[str]) -> Dict[str
     access_modes: Dict[str, AccessMode] = {}
 
     for node in ast.walk(AST):
+        # For now, treat any view passed to a call as a RW access
+        if isinstance(node, ast.Call):
+            for arg in node.args:
+                if not isinstance(arg, ast.Name):
+                    continue
+                if arg.id in view_args:
+                    access_modes[arg.id] = AccessMode.ReadWrite
+            continue
+
         if not isinstance(node, ast.Subscript): # We are only interested in view accesses
             continue
 

--- a/pykokkos/core/fusion/trace.py
+++ b/pykokkos/core/fusion/trace.py
@@ -242,7 +242,7 @@ class Tracer:
             assert isinstance(op.policy, RangePolicy) and policy.begin == op.policy.begin and policy.end == op.policy.end
             assert operation == op.operation == "for"
 
-            names.append(op.name)
+            names.append(op.name if op.name is not None else op.workunit.__name__)
             workunits.append(op.workunit)
             args[f"args_{index}"] = op.args
             dependencies.update(op.dependencies)


### PR DESCRIPTION
For now, we will treat views passed to `@pk.function` calls as ReadWrite access. In the future, we need to parse the functions being called as well. This PR also fixes an issue when fusing workunits that are not named.