### PR TITLE
ufuncs: Added subtract support for 2D views

### DIFF
--- a/pre_compile_tools/pre_compile_ufuncs.py
+++ b/pre_compile_tools/pre_compile_ufuncs.py
@@ -55,6 +55,9 @@ def main():
                     func_obj(v, v)
                 except (NotImplementedError, KeyError):
                     pass
+                except ValueError:
+                    if "broadcast" in func[0]:
+                        pass
                 except TypeError:
                     try:
                         func_obj(v)

--- a/pre_compile_tools/pre_compile_ufuncs.py
+++ b/pre_compile_tools/pre_compile_ufuncs.py
@@ -27,7 +27,7 @@ def main():
     # level kernels/workunits directly
     filtered_function_list = []
     for f in function_list:
-        if not "impl" in f[0] and not f[0].startswith("_"):
+        if not "impl" in f[0] and not f[0].startswith("_") or ("broadcast_view" not in f[0]):
             filtered_function_list.append(f)
     # TODO: expand types and view dimensions for
     # ufunc pre-compilation as the support
@@ -55,9 +55,6 @@ def main():
                     func_obj(v, v)
                 except (NotImplementedError, KeyError):
                     pass
-                except ValueError:
-                    if "broadcast" in func[0]:
-                        pass
                 except TypeError:
                     try:
                         func_obj(v)

--- a/pre_compile_tools/pre_compile_ufuncs.py
+++ b/pre_compile_tools/pre_compile_ufuncs.py
@@ -27,7 +27,7 @@ def main():
     # level kernels/workunits directly
     filtered_function_list = []
     for f in function_list:
-        if not "impl" in f[0] and not f[0].startswith("_") or ("broadcast_view" not in f[0]):
+        if not "impl" in f[0] and not f[0].startswith("_") and "broadcast_view" not in f[0]:
             filtered_function_list.append(f)
     # TODO: expand types and view dimensions for
     # ufunc pre-compilation as the support

--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -62,7 +62,8 @@ from pykokkos.lib.ufuncs import (reciprocal,
                                  round,
                                  trunc,
                                  ceil,
-                                 floor)
+                                 floor,
+                                 broadcast_view)
 from pykokkos.lib.info import iinfo, finfo
 from pykokkos.lib.create import (zeros,
                                  zeros_like,

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1153,7 +1153,7 @@ def subtract(viewA, valB):
 
     if not is_scalar:
 
-        if not check_broadcastable_impl(viewA, valB):
+        if viewA.shape != valB.shape and not check_broadcastable_impl(viewA, valB): # if shape is not same check compatibility
             raise ValueError("Views must be broadcastable")
 
         # check if size is same otherwise broadcast and fix

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1059,7 +1059,7 @@ def broadcast_view(val, viewB):
         if not val.dtype == viewB.dtype: 
             raise ValueError("Broadcastable views must have same dtypes")
 
-    out = pk.View([dim for dim in viewB.shape], viewB.dtype)
+    out = pk.View(viewB.shape, viewB.dtype)
 
     if is_view:
         # if both 2D
@@ -1079,7 +1079,7 @@ def broadcast_view(val, viewB):
     # scalar
 
     if len(viewB.shape) == 1:
-        out_1d = pk.View([viewB.shape[1] if len(viewB.shape)==2 else viewB.shape[0]])
+        out_1d = pk.View(viewB.shape)
         pk.parallel_for(viewB.shape[0], stretch_fill_impl_scalar_into_1d, scalar=val, viewOut=out_1d)
         return out_1d
 
@@ -1165,7 +1165,7 @@ def subtract(viewA, valB):
         if viewA.dtype.__name__ == "float64" and valB.dtype.__name__ == "float64":
 
             if len(viewA.shape) == 1:
-                out = pk.View([viewA.shape[0]], pk.double)
+                out = pk.View(viewA.shape, pk.double)
                 pk.parallel_for(
                     viewA.shape[0],
                     subtract_impl_1d_double,
@@ -1187,7 +1187,7 @@ def subtract(viewA, valB):
         elif viewA.dtype.__name__ == "float32" and valB.dtype.__name__ == "float32":
 
             if len(viewA.shape) == 1:
-                out = pk.View([viewA.shape[0]], pk.float)
+                out = pk.View(viewA.shape, pk.float)
                 pk.parallel_for(
                     viewA.shape[0],
                     subtract_impl_1d_float,
@@ -1215,9 +1215,9 @@ def subtract(viewA, valB):
     if len(viewA.shape) == 1: # 1D
         out = None
         if viewA.dtype.__name__ == "float64":
-            out = pk.View([viewA.shape[0]], pk.double)
+            out = pk.View(viewA.shape, pk.double)
         if viewA.dtype.__name__ == "float32":
-            out = pk.View([viewA.shape[0]], pk.float)
+            out = pk.View(viewA.shape, pk.float)
         
         if out is None: raise RuntimeError("Incompatible Types")
 

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1151,9 +1151,9 @@ def subtract(viewA, valB):
         assert check_broadcastable_impl(viewA, valB), "Views must be broadcastable"
 
         # check if size is same otherwise broadcast and fix
-        if len(viewA.shape) < len(valB.shape):
+        if viewA.shape < valB.shape:
             viewA = broadcast_view(viewA, valB)
-        elif len(valB.shape) < len(viewA.shape):
+        elif valB.shape < viewA.shape:
             valB = broadcast_view(valB, viewA)
 
         if viewA.dtype.__name__ == "float64" and valB.dtype.__name__ == "float64":

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1037,7 +1037,7 @@ def broadcast_view(val, viewB):
         return out
 
     # scalar
-
+    #TODO This is very dumb. ALl you need to do is put scalar at every index. Go sleep
     out_1d = pk.View([viewB.shape[1] if len(viewB.shape)==2 else viewB.shape[0]])
     pk.parallel_for(viewB.shape[0], stretch_fill_impl_scalar_into_1d, scalar=val, viewOut=out_1d)
 

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1054,7 +1054,7 @@ def broadcast_view(val, viewB):
             val = val[0] if len(val.shape) == 1 else val[0][0]
 
     if is_view:
-        if not check_broadcastable_impl(val, viewB) and val.shape < viewB.shape:
+        if not check_broadcastable_impl(val, viewB) or not val.shape < viewB.shape:
             raise ValueError("Incompatible broadcast")
         if not val.dtype == viewB.dtype: 
             raise ValueError("Broadcastable views must have same dtypes")

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -973,7 +973,7 @@ def subtract_impl_2d(team_member, cols, viewA, viewB, viewOut):
     j: int = team_member.league_rank()
 
     def row_sub(i: int):
-        viewOut[j][i] = viewA[j][i] - viewB[j][j]
+        viewOut[j][i] = viewA[j][i] - viewB[j][i]
     
     pk.parallel_for(pk.TeamThreadRange(team_member, cols), row_sub)
 

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -1051,8 +1051,10 @@ def broadcast_view(val, viewB):
             val = val[0] if len(val.shape) == 1 else val[0][0]
 
     if is_view:
-        assert check_broadcastable_impl(val, viewB) and val.shape < viewB.shape, "Incompatible broadcast"
-        assert val.dtype == viewB.dtype, "Broadcastable views must have same dtypes"
+        if not check_broadcastable_impl(val, viewB) and val.shape < viewB.shape:
+            raise ValueError("Incompatible broadcast")
+        if not val.dtype == viewB.dtype: 
+            raise ValueError("Broadcastable views must have same dtypes")
 
     out = pk.View([dim for dim in viewB.shape], viewB.dtype)
 
@@ -1148,7 +1150,8 @@ def subtract(viewA, valB):
 
     if not is_scalar:
 
-        assert check_broadcastable_impl(viewA, valB), "Views must be broadcastable"
+        if not check_broadcastable_impl(viewA, valB):
+            raise ValueError("Views must be broadcastable")
 
         # check if size is same otherwise broadcast and fix
         if viewA.shape < valB.shape:

--- a/pykokkos/lib/ufuncs.py
+++ b/pykokkos/lib/ufuncs.py
@@ -978,6 +978,9 @@ def check_broadcastable_impl(viewA, viewB):
            True if both views are compatible.
     """
 
+    if viewA.shape == viewB.shape:
+        return False # cannot broadcast same dims
+
     v1_p = len(viewA.shape) -1
     v2_p = len(viewB.shape) -1
 
@@ -1060,7 +1063,7 @@ def broadcast_view(val, viewB):
 
     if is_view:
         # if both 2D
-        if len(val.shape) == 2:
+        if len(val.shape) == 2: #viewB must be 2 because of the val.shape < viewB.shape check
             # figure which orientation is val (row or col)
             col_wise = 1 if val.shape[1] == 1 else 0
             inner_its = viewB.shape[0] if col_wise else viewB.shape[1]

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -258,205 +258,205 @@ class ReciprocalView1D:
     def pfor(self, tid: int) -> None:
         self.view[tid] = reciprocal(self.view[tid])
 
-# @pytest.mark.parametrize("kokkos_test_class, numpy_ufunc", [
-#     (SqrtView1D, np.sqrt),
-#     (ExpView1D, np.exp),
-#     pytest.param(Exp2View1D, np.exp2, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(PositiveView1D, np.positive, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(NegativeView1D, np.negative, marks=pytest.mark.xfail(reason="see gh-27")),
-#     (AbsoluteView1D, np.absolute),
-#     (FabsoluteView1D, np.fabs),
-#     pytest.param(RintView1D, np.rint, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(ConjugateView1D, np.conjugate, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(SignView1D, np.sign, marks=pytest.mark.xfail(reason="see gh-27")),
-#     (LogView1D, np.log),
-#     (Log2View1D, np.log2),
-#     (Log10View1D, np.log10),
-#     (Expm1View1D, np.expm1),
-#     (Log1pView1D, np.log1p),
-#     pytest.param(SquareView1D, np.square, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(CbrtView1D, np.cbrt, marks=pytest.mark.xfail(reason="see gh-27")),
-#     pytest.param(ReciprocalView1D, np.reciprocal, marks=pytest.mark.xfail(reason="see gh-27")),
-# ])
-# def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
-#     # verify that we can easily recreate the functionality
-#     # of most NumPy "unary" ufuncs on 1D views/arrays without much
-#     # custom code
-#     # NOTE: maybe we directly provide i.e., pk.sqrt(view)
-#     # "pykokkos ufuncs" some day?
-#     view: pk.View1d = pk.View([10], pk.double)
-#     view[:] = np.arange(10, dtype=np.float64)
-#     kokkos_instance = kokkos_test_class(threads=10, view=view)
-#     pk.execute(pk.ExecutionSpace.Default, kokkos_instance)
-#     actual = kokkos_instance.view
-#     expected = numpy_ufunc(range(10))
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize("kokkos_test_class, numpy_ufunc", [
+    (SqrtView1D, np.sqrt),
+    (ExpView1D, np.exp),
+    pytest.param(Exp2View1D, np.exp2, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(PositiveView1D, np.positive, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(NegativeView1D, np.negative, marks=pytest.mark.xfail(reason="see gh-27")),
+    (AbsoluteView1D, np.absolute),
+    (FabsoluteView1D, np.fabs),
+    pytest.param(RintView1D, np.rint, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(ConjugateView1D, np.conjugate, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(SignView1D, np.sign, marks=pytest.mark.xfail(reason="see gh-27")),
+    (LogView1D, np.log),
+    (Log2View1D, np.log2),
+    (Log10View1D, np.log10),
+    (Expm1View1D, np.expm1),
+    (Log1pView1D, np.log1p),
+    pytest.param(SquareView1D, np.square, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(CbrtView1D, np.cbrt, marks=pytest.mark.xfail(reason="see gh-27")),
+    pytest.param(ReciprocalView1D, np.reciprocal, marks=pytest.mark.xfail(reason="see gh-27")),
+])
+def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
+    # verify that we can easily recreate the functionality
+    # of most NumPy "unary" ufuncs on 1D views/arrays without much
+    # custom code
+    # NOTE: maybe we directly provide i.e., pk.sqrt(view)
+    # "pykokkos ufuncs" some day?
+    view: pk.View1d = pk.View([10], pk.double)
+    view[:] = np.arange(10, dtype=np.float64)
+    kokkos_instance = kokkos_test_class(threads=10, view=view)
+    pk.execute(pk.ExecutionSpace.Default, kokkos_instance)
+    actual = kokkos_instance.view
+    expected = numpy_ufunc(range(10))
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-#         (pk.reciprocal, np.reciprocal),
-#         (pk.log, np.log),
-#         (pk.log2, np.log2),
-#         (pk.log10, np.log10),
-#         (pk.log1p, np.log1p),
-#         (pk.sqrt, np.sqrt),
-#         (pk.sign, np.sign),
-#         (pk.negative, np.negative),
-#         (pk.positive, np.positive),
-#         (pk.square, np.square),
-#         (pk.sin, np.sin),
-#         (pk.cos, np.cos),
-#         (pk.tan, np.tan),
-#         (pk.logical_not, np.logical_not),
-#         (pk.exp, np.exp),
-#         (pk.exp2, np.exp2),
-# ])
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-#                                     numpy_ufunc,
-#                                     pk_dtype,
-#                                     numpy_dtype):
-#     # test the ufuncs we have exposed in the pk namespace
-#     # vs. their NumPy equivalents
-#     expected = numpy_ufunc(np.arange(10, dtype=numpy_dtype))
+@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+        (pk.reciprocal, np.reciprocal),
+        (pk.log, np.log),
+        (pk.log2, np.log2),
+        (pk.log10, np.log10),
+        (pk.log1p, np.log1p),
+        (pk.sqrt, np.sqrt),
+        (pk.sign, np.sign),
+        (pk.negative, np.negative),
+        (pk.positive, np.positive),
+        (pk.square, np.square),
+        (pk.sin, np.sin),
+        (pk.cos, np.cos),
+        (pk.tan, np.tan),
+        (pk.logical_not, np.logical_not),
+        (pk.exp, np.exp),
+        (pk.exp2, np.exp2),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                    numpy_ufunc,
+                                    pk_dtype,
+                                    numpy_dtype):
+    # test the ufuncs we have exposed in the pk namespace
+    # vs. their NumPy equivalents
+    expected = numpy_ufunc(np.arange(10, dtype=numpy_dtype))
 
-#     view: pk.View1d = pk.View([10], pk_dtype)
-#     view[:] = np.arange(10, dtype=numpy_dtype)
-#     actual = pk_ufunc(view=view)
-#     # log10 single-precision needs relaxed tol
-#     # for now
-#     if numpy_ufunc in {np.log10, np.cos, np.tan} and numpy_dtype == np.float32:
-#         assert_allclose(actual, expected, rtol=1.5e-7)
-#     else:
-#         assert_allclose(actual, expected)
-
-
-# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-#         (pk.add, np.add),
-#         (pk.subtract, np.subtract),
-#         (pk.multiply, np.multiply),
-#         (pk.divide, np.divide),
-#         (pk.power, np.power),
-#         (pk.fmod, np.fmod),
-#         (pk.greater, np.greater),
-#         (pk.logaddexp, np.logaddexp),
-#         (pk.floor_divide, np.floor_divide),
-#         (pk.true_divide, np.true_divide),
-#         (pk.logaddexp2, np.logaddexp2),
-#         (pk.logical_and, np.logical_and),
-#         (pk.logical_or, np.logical_or),
-#         (pk.logical_xor, np.logical_xor),
-#         (pk.fmax, np.fmax),
-#         (pk.fmin, np.fmin),
-
-# ])
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# def test_multi_array_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-#                                     numpy_ufunc,
-#                                     pk_dtype,
-#                                     numpy_dtype):
-
-#     # test the multi array ufuncs we have exposed 
-#     # in the pk namespace vs. their NumPy equivalents
-#     expected = numpy_ufunc(
-#         np.arange(10, dtype=numpy_dtype),
-#         np.full(10, 5, dtype=numpy_dtype))
-
-#     viewA: pk.View1d = pk.View([10], pk_dtype)
-#     viewA[:] = np.arange(10, dtype=numpy_dtype)
-#     viewB: pk.View1d = pk.View([10], pk_dtype)
-#     viewB[:] = np.full(10, 5, dtype=numpy_dtype)
-
-#     actual = pk_ufunc(viewA=viewA, viewB=viewB)
-
-#     assert_allclose(actual, expected)
+    view: pk.View1d = pk.View([10], pk_dtype)
+    view[:] = np.arange(10, dtype=numpy_dtype)
+    actual = pk_ufunc(view=view)
+    # log10 single-precision needs relaxed tol
+    # for now
+    if numpy_ufunc in {np.log10, np.cos, np.tan} and numpy_dtype == np.float32:
+        assert_allclose(actual, expected, rtol=1.5e-7)
+    else:
+        assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-#         (pk.matmul, np.matmul),
-# ])
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# def test_matmul_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-#                                     numpy_ufunc,
-#                                     pk_dtype,
-#                                     numpy_dtype):
-#     expected = numpy_ufunc(
-#         np.arange(10, dtype=numpy_dtype),
-#         np.full((10, 1), 2, dtype=numpy_dtype))
+@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+        (pk.add, np.add),
+        (pk.subtract, np.subtract),
+        (pk.multiply, np.multiply),
+        (pk.divide, np.divide),
+        (pk.power, np.power),
+        (pk.fmod, np.fmod),
+        (pk.greater, np.greater),
+        (pk.logaddexp, np.logaddexp),
+        (pk.floor_divide, np.floor_divide),
+        (pk.true_divide, np.true_divide),
+        (pk.logaddexp2, np.logaddexp2),
+        (pk.logical_and, np.logical_and),
+        (pk.logical_or, np.logical_or),
+        (pk.logical_xor, np.logical_xor),
+        (pk.fmax, np.fmax),
+        (pk.fmin, np.fmin),
+
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_multi_array_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                    numpy_ufunc,
+                                    pk_dtype,
+                                    numpy_dtype):
+
+    # test the multi array ufuncs we have exposed 
+    # in the pk namespace vs. their NumPy equivalents
+    expected = numpy_ufunc(
+        np.arange(10, dtype=numpy_dtype),
+        np.full(10, 5, dtype=numpy_dtype))
+
+    viewA: pk.View1d = pk.View([10], pk_dtype)
+    viewA[:] = np.arange(10, dtype=numpy_dtype)
+    viewB: pk.View1d = pk.View([10], pk_dtype)
+    viewB[:] = np.full(10, 5, dtype=numpy_dtype)
+
+    actual = pk_ufunc(viewA=viewA, viewB=viewB)
+
+    assert_allclose(actual, expected)
 
 
-#     viewA = pk.View([10], pk_dtype)
-#     viewB = pk.View([10, 1], pk_dtype)
-#     viewA[:] = np.arange(10, dtype=numpy_dtype)
-#     viewB[:] = np.full((10, 1), 2, dtype=numpy_dtype)
-
-#     with pytest.raises(RuntimeError) as e_info:
-#         viewC = pk.View([11], pk_dtype)
-#         viewC[:] = np.arange(11, dtype=numpy_dtype)
-#         pk_ufunc(viewC, viewB)
-
-#     assert e_info.value.args[0] == "Input operand 1 has a mismatch in its core dimension (Size 11 is different from 10)"
-
-#     actual = pk_ufunc(viewA, viewB)
-
-#     assert_allclose(actual, expected)
-
-# @pytest.mark.parametrize("arr", [
-#     np.array([4, -1, np.inf]),
-#     np.array([-np.inf, np.nan, np.inf]),
-# ])
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
-#     # verify sqrt behavior for negative reals,
-#     # NaN and infinite values
-#     expected = np.sqrt(arr, dtype=numpy_dtype)
-#     view: pk.View1d = pk.View([arr.size], pk_dtype)
-#     view[:] = arr
-#     actual = pk.sqrt(view=view)
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+        (pk.matmul, np.matmul),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_matmul_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                    numpy_ufunc,
+                                    pk_dtype,
+                                    numpy_dtype):
+    expected = numpy_ufunc(
+        np.arange(10, dtype=numpy_dtype),
+        np.full((10, 1), 2, dtype=numpy_dtype))
 
 
-# def test_caching():
-#     # regression test for gh-34
-#     expected = np.reciprocal(np.arange(10, dtype=np.float32))
-#     for i in range(300):
-#         view: pk.View1d = pk.View([10], pk.float)
-#         view[:] = np.arange(10, dtype=np.float32)
-#         actual = pk.reciprocal(view=view)
-#         assert_allclose(actual, expected)
+    viewA = pk.View([10], pk_dtype)
+    viewB = pk.View([10, 1], pk_dtype)
+    viewA[:] = np.arange(10, dtype=numpy_dtype)
+    viewB[:] = np.full((10, 1), 2, dtype=numpy_dtype)
+
+    with pytest.raises(RuntimeError) as e_info:
+        viewC = pk.View([11], pk_dtype)
+        viewC[:] = np.arange(11, dtype=numpy_dtype)
+        pk_ufunc(viewC, viewB)
+
+    assert e_info.value.args[0] == "Input operand 1 has a mismatch in its core dimension (Size 11 is different from 10)"
+
+    actual = pk_ufunc(viewA, viewB)
+
+    assert_allclose(actual, expected)
+
+@pytest.mark.parametrize("arr", [
+    np.array([4, -1, np.inf]),
+    np.array([-np.inf, np.nan, np.inf]),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
+    # verify sqrt behavior for negative reals,
+    # NaN and infinite values
+    expected = np.sqrt(arr, dtype=numpy_dtype)
+    view: pk.View1d = pk.View([arr.size], pk_dtype)
+    view[:] = arr
+    actual = pk.sqrt(view=view)
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-#         (pk.reciprocal, np.reciprocal),
-# ])
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# def test_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
-#                                     numpy_ufunc,
-#                                     pk_dtype,
-#                                     numpy_dtype):
-#     rng = default_rng(123)
-#     in_arr = rng.random((5, 5)).astype(numpy_dtype)
-#     expected = numpy_ufunc(in_arr)
+def test_caching():
+    # regression test for gh-34
+    expected = np.reciprocal(np.arange(10, dtype=np.float32))
+    for i in range(300):
+        view: pk.View1d = pk.View([10], pk.float)
+        view[:] = np.arange(10, dtype=np.float32)
+        actual = pk.reciprocal(view=view)
+        assert_allclose(actual, expected)
 
-#     view: pk.View2d = pk.View([5, 5], pk_dtype)
-#     view[:] = in_arr
-#     actual = pk_ufunc(view=view)
-#     assert_allclose(actual, expected)
+
+@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+        (pk.reciprocal, np.reciprocal),
+])
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+def test_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                    numpy_ufunc,
+                                    pk_dtype,
+                                    numpy_dtype):
+    rng = default_rng(123)
+    in_arr = rng.random((5, 5)).astype(numpy_dtype)
+    expected = numpy_ufunc(in_arr)
+
+    view: pk.View2d = pk.View([5, 5], pk_dtype)
+    view[:] = in_arr
+    actual = pk_ufunc(view=view)
+    assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
@@ -483,44 +483,44 @@ def test_multi_array_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
 
     assert_allclose(actual, expected)
 
-# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-#         (pk.double, np.float64),
-#         (pk.float, np.float32),
-# ])
-# @pytest.mark.parametrize("in_arr", [
-#     np.array([-5, 4.5, np.nan]),
-#     np.array([np.nan, np.nan, np.nan]),
-# ])
-# def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
-#     in_arr = in_arr.astype(numpy_dtype)
-#     view: pk.View1D = pk.View([in_arr.size], pk_dtype)
-#     view[:] = in_arr
-#     expected = np.sign(in_arr)
-#     actual = pk.sign(view=view)
-#     assert_allclose(actual, expected)
+@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+        (pk.double, np.float64),
+        (pk.float, np.float32),
+])
+@pytest.mark.parametrize("in_arr", [
+    np.array([-5, 4.5, np.nan]),
+    np.array([np.nan, np.nan, np.nan]),
+])
+def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
+    in_arr = in_arr.astype(numpy_dtype)
+    view: pk.View1D = pk.View([in_arr.size], pk_dtype)
+    view[:] = in_arr
+    expected = np.sign(in_arr)
+    actual = pk.sign(view=view)
+    assert_allclose(actual, expected)
 
 
-# @pytest.mark.parametrize("input_dtype", [
-#         pk.double, pk.float,
-# ])
-# @pytest.mark.parametrize("pk_ufunc", [
-#         pk.floor,
-#         pk.round,
-#         pk.ceil,
-#         pk.trunc,
-# ])
-# @pytest.mark.parametrize("shape", [
-#         [1], [1, 1], [1, 1, 1],
-# ])
-# def test_rounding_dtype_preservation(input_dtype, pk_ufunc, shape):
-#     # at the time of writing the array API standard
-#     # conformance test suite doesn't appear to probe
-#     # floating point data types for many of the rounding
-#     # functions
+@pytest.mark.parametrize("input_dtype", [
+        pk.double, pk.float,
+])
+@pytest.mark.parametrize("pk_ufunc", [
+        pk.floor,
+        pk.round,
+        pk.ceil,
+        pk.trunc,
+])
+@pytest.mark.parametrize("shape", [
+        [1], [1, 1], [1, 1, 1],
+])
+def test_rounding_dtype_preservation(input_dtype, pk_ufunc, shape):
+    # at the time of writing the array API standard
+    # conformance test suite doesn't appear to probe
+    # floating point data types for many of the rounding
+    # functions
 
-#     # for now, we simply test data type preservation
-#     # of output vs. input so that we flush these codepaths
-#     # a bit
-#     view = pk.View(shape, input_dtype)
-#     actual_dtype = pk_ufunc(view).dtype
-#     assert actual_dtype.value == input_dtype.value
+    # for now, we simply test data type preservation
+    # of output vs. input so that we flush these codepaths
+    # a bit
+    view = pk.View(shape, input_dtype)
+    actual_dtype = pk_ufunc(view).dtype
+    assert actual_dtype.value == input_dtype.value

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -258,245 +258,269 @@ class ReciprocalView1D:
     def pfor(self, tid: int) -> None:
         self.view[tid] = reciprocal(self.view[tid])
 
-@pytest.mark.parametrize("kokkos_test_class, numpy_ufunc", [
-    (SqrtView1D, np.sqrt),
-    (ExpView1D, np.exp),
-    pytest.param(Exp2View1D, np.exp2, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(PositiveView1D, np.positive, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(NegativeView1D, np.negative, marks=pytest.mark.xfail(reason="see gh-27")),
-    (AbsoluteView1D, np.absolute),
-    (FabsoluteView1D, np.fabs),
-    pytest.param(RintView1D, np.rint, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(ConjugateView1D, np.conjugate, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(SignView1D, np.sign, marks=pytest.mark.xfail(reason="see gh-27")),
-    (LogView1D, np.log),
-    (Log2View1D, np.log2),
-    (Log10View1D, np.log10),
-    (Expm1View1D, np.expm1),
-    (Log1pView1D, np.log1p),
-    pytest.param(SquareView1D, np.square, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(CbrtView1D, np.cbrt, marks=pytest.mark.xfail(reason="see gh-27")),
-    pytest.param(ReciprocalView1D, np.reciprocal, marks=pytest.mark.xfail(reason="see gh-27")),
-])
-def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
-    # verify that we can easily recreate the functionality
-    # of most NumPy "unary" ufuncs on 1D views/arrays without much
-    # custom code
-    # NOTE: maybe we directly provide i.e., pk.sqrt(view)
-    # "pykokkos ufuncs" some day?
-    view: pk.View1d = pk.View([10], pk.double)
-    view[:] = np.arange(10, dtype=np.float64)
-    kokkos_instance = kokkos_test_class(threads=10, view=view)
-    pk.execute(pk.ExecutionSpace.Default, kokkos_instance)
-    actual = kokkos_instance.view
-    expected = numpy_ufunc(range(10))
-    assert_allclose(actual, expected)
+# @pytest.mark.parametrize("kokkos_test_class, numpy_ufunc", [
+#     (SqrtView1D, np.sqrt),
+#     (ExpView1D, np.exp),
+#     pytest.param(Exp2View1D, np.exp2, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(PositiveView1D, np.positive, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(NegativeView1D, np.negative, marks=pytest.mark.xfail(reason="see gh-27")),
+#     (AbsoluteView1D, np.absolute),
+#     (FabsoluteView1D, np.fabs),
+#     pytest.param(RintView1D, np.rint, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(ConjugateView1D, np.conjugate, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(SignView1D, np.sign, marks=pytest.mark.xfail(reason="see gh-27")),
+#     (LogView1D, np.log),
+#     (Log2View1D, np.log2),
+#     (Log10View1D, np.log10),
+#     (Expm1View1D, np.expm1),
+#     (Log1pView1D, np.log1p),
+#     pytest.param(SquareView1D, np.square, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(CbrtView1D, np.cbrt, marks=pytest.mark.xfail(reason="see gh-27")),
+#     pytest.param(ReciprocalView1D, np.reciprocal, marks=pytest.mark.xfail(reason="see gh-27")),
+# ])
+# def test_1d_unary_ufunc_vs_numpy(kokkos_test_class, numpy_ufunc):
+#     # verify that we can easily recreate the functionality
+#     # of most NumPy "unary" ufuncs on 1D views/arrays without much
+#     # custom code
+#     # NOTE: maybe we directly provide i.e., pk.sqrt(view)
+#     # "pykokkos ufuncs" some day?
+#     view: pk.View1d = pk.View([10], pk.double)
+#     view[:] = np.arange(10, dtype=np.float64)
+#     kokkos_instance = kokkos_test_class(threads=10, view=view)
+#     pk.execute(pk.ExecutionSpace.Default, kokkos_instance)
+#     actual = kokkos_instance.view
+#     expected = numpy_ufunc(range(10))
+#     assert_allclose(actual, expected)
+
+
+# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+#         (pk.reciprocal, np.reciprocal),
+#         (pk.log, np.log),
+#         (pk.log2, np.log2),
+#         (pk.log10, np.log10),
+#         (pk.log1p, np.log1p),
+#         (pk.sqrt, np.sqrt),
+#         (pk.sign, np.sign),
+#         (pk.negative, np.negative),
+#         (pk.positive, np.positive),
+#         (pk.square, np.square),
+#         (pk.sin, np.sin),
+#         (pk.cos, np.cos),
+#         (pk.tan, np.tan),
+#         (pk.logical_not, np.logical_not),
+#         (pk.exp, np.exp),
+#         (pk.exp2, np.exp2),
+# ])
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+#                                     numpy_ufunc,
+#                                     pk_dtype,
+#                                     numpy_dtype):
+#     # test the ufuncs we have exposed in the pk namespace
+#     # vs. their NumPy equivalents
+#     expected = numpy_ufunc(np.arange(10, dtype=numpy_dtype))
+
+#     view: pk.View1d = pk.View([10], pk_dtype)
+#     view[:] = np.arange(10, dtype=numpy_dtype)
+#     actual = pk_ufunc(view=view)
+#     # log10 single-precision needs relaxed tol
+#     # for now
+#     if numpy_ufunc in {np.log10, np.cos, np.tan} and numpy_dtype == np.float32:
+#         assert_allclose(actual, expected, rtol=1.5e-7)
+#     else:
+#         assert_allclose(actual, expected)
+
+
+# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+#         (pk.add, np.add),
+#         (pk.subtract, np.subtract),
+#         (pk.multiply, np.multiply),
+#         (pk.divide, np.divide),
+#         (pk.power, np.power),
+#         (pk.fmod, np.fmod),
+#         (pk.greater, np.greater),
+#         (pk.logaddexp, np.logaddexp),
+#         (pk.floor_divide, np.floor_divide),
+#         (pk.true_divide, np.true_divide),
+#         (pk.logaddexp2, np.logaddexp2),
+#         (pk.logical_and, np.logical_and),
+#         (pk.logical_or, np.logical_or),
+#         (pk.logical_xor, np.logical_xor),
+#         (pk.fmax, np.fmax),
+#         (pk.fmin, np.fmin),
+
+# ])
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# def test_multi_array_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+#                                     numpy_ufunc,
+#                                     pk_dtype,
+#                                     numpy_dtype):
+
+#     # test the multi array ufuncs we have exposed 
+#     # in the pk namespace vs. their NumPy equivalents
+#     expected = numpy_ufunc(
+#         np.arange(10, dtype=numpy_dtype),
+#         np.full(10, 5, dtype=numpy_dtype))
+
+#     viewA: pk.View1d = pk.View([10], pk_dtype)
+#     viewA[:] = np.arange(10, dtype=numpy_dtype)
+#     viewB: pk.View1d = pk.View([10], pk_dtype)
+#     viewB[:] = np.full(10, 5, dtype=numpy_dtype)
+
+#     actual = pk_ufunc(viewA=viewA, viewB=viewB)
+
+#     assert_allclose(actual, expected)
+
+
+# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+#         (pk.matmul, np.matmul),
+# ])
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# def test_matmul_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
+#                                     numpy_ufunc,
+#                                     pk_dtype,
+#                                     numpy_dtype):
+#     expected = numpy_ufunc(
+#         np.arange(10, dtype=numpy_dtype),
+#         np.full((10, 1), 2, dtype=numpy_dtype))
+
+
+#     viewA = pk.View([10], pk_dtype)
+#     viewB = pk.View([10, 1], pk_dtype)
+#     viewA[:] = np.arange(10, dtype=numpy_dtype)
+#     viewB[:] = np.full((10, 1), 2, dtype=numpy_dtype)
+
+#     with pytest.raises(RuntimeError) as e_info:
+#         viewC = pk.View([11], pk_dtype)
+#         viewC[:] = np.arange(11, dtype=numpy_dtype)
+#         pk_ufunc(viewC, viewB)
+
+#     assert e_info.value.args[0] == "Input operand 1 has a mismatch in its core dimension (Size 11 is different from 10)"
+
+#     actual = pk_ufunc(viewA, viewB)
+
+#     assert_allclose(actual, expected)
+
+# @pytest.mark.parametrize("arr", [
+#     np.array([4, -1, np.inf]),
+#     np.array([-np.inf, np.nan, np.inf]),
+# ])
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
+#     # verify sqrt behavior for negative reals,
+#     # NaN and infinite values
+#     expected = np.sqrt(arr, dtype=numpy_dtype)
+#     view: pk.View1d = pk.View([arr.size], pk_dtype)
+#     view[:] = arr
+#     actual = pk.sqrt(view=view)
+#     assert_allclose(actual, expected)
+
+
+# def test_caching():
+#     # regression test for gh-34
+#     expected = np.reciprocal(np.arange(10, dtype=np.float32))
+#     for i in range(300):
+#         view: pk.View1d = pk.View([10], pk.float)
+#         view[:] = np.arange(10, dtype=np.float32)
+#         actual = pk.reciprocal(view=view)
+#         assert_allclose(actual, expected)
+
+
+# @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
+#         (pk.reciprocal, np.reciprocal),
+# ])
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# def test_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
+#                                     numpy_ufunc,
+#                                     pk_dtype,
+#                                     numpy_dtype):
+#     rng = default_rng(123)
+#     in_arr = rng.random((5, 5)).astype(numpy_dtype)
+#     expected = numpy_ufunc(in_arr)
+
+#     view: pk.View2d = pk.View([5, 5], pk_dtype)
+#     view[:] = in_arr
+#     actual = pk_ufunc(view=view)
+#     assert_allclose(actual, expected)
 
 
 @pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-        (pk.reciprocal, np.reciprocal),
-        (pk.log, np.log),
-        (pk.log2, np.log2),
-        (pk.log10, np.log10),
-        (pk.log1p, np.log1p),
-        (pk.sqrt, np.sqrt),
-        (pk.sign, np.sign),
-        (pk.negative, np.negative),
-        (pk.positive, np.positive),
-        (pk.square, np.square),
-        (pk.sin, np.sin),
-        (pk.cos, np.cos),
-        (pk.tan, np.tan),
-        (pk.logical_not, np.logical_not),
-        (pk.exp, np.exp),
-        (pk.exp2, np.exp2),
-])
-@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-        (pk.double, np.float64),
-        (pk.float, np.float32),
-])
-def test_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-                                    numpy_ufunc,
-                                    pk_dtype,
-                                    numpy_dtype):
-    # test the ufuncs we have exposed in the pk namespace
-    # vs. their NumPy equivalents
-    expected = numpy_ufunc(np.arange(10, dtype=numpy_dtype))
-
-    view: pk.View1d = pk.View([10], pk_dtype)
-    view[:] = np.arange(10, dtype=numpy_dtype)
-    actual = pk_ufunc(view=view)
-    # log10 single-precision needs relaxed tol
-    # for now
-    if numpy_ufunc in {np.log10, np.cos, np.tan} and numpy_dtype == np.float32:
-        assert_allclose(actual, expected, rtol=1.5e-7)
-    else:
-        assert_allclose(actual, expected)
-
-
-@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-        (pk.add, np.add),
         (pk.subtract, np.subtract),
-        (pk.multiply, np.multiply),
-        (pk.divide, np.divide),
-        (pk.power, np.power),
-        (pk.fmod, np.fmod),
-        (pk.greater, np.greater),
-        (pk.logaddexp, np.logaddexp),
-        (pk.floor_divide, np.floor_divide),
-        (pk.true_divide, np.true_divide),
-        (pk.logaddexp2, np.logaddexp2),
-        (pk.logical_and, np.logical_and),
-        (pk.logical_or, np.logical_or),
-        (pk.logical_xor, np.logical_xor),
-        (pk.fmax, np.fmax),
-        (pk.fmin, np.fmin),
-
 ])
 @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
         (pk.double, np.float64),
         (pk.float, np.float32),
 ])
-def test_multi_array_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-                                    numpy_ufunc,
-                                    pk_dtype,
-                                    numpy_dtype):
-
-    # test the multi array ufuncs we have exposed 
-    # in the pk namespace vs. their NumPy equivalents
-    expected = numpy_ufunc(
-        np.arange(10, dtype=numpy_dtype),
-        np.full(10, 5, dtype=numpy_dtype))
-
-    viewA: pk.View1d = pk.View([10], pk_dtype)
-    viewA[:] = np.arange(10, dtype=numpy_dtype)
-    viewB: pk.View1d = pk.View([10], pk_dtype)
-    viewB[:] = np.full(10, 5, dtype=numpy_dtype)
-
-    actual = pk_ufunc(viewA=viewA, viewB=viewB)
-
-    assert_allclose(actual, expected)
-
-
-@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-        (pk.matmul, np.matmul),
-])
-@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-        (pk.double, np.float64),
-        (pk.float, np.float32),
-])
-def test_matmul_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
-                                    numpy_ufunc,
-                                    pk_dtype,
-                                    numpy_dtype):
-    expected = numpy_ufunc(
-        np.arange(10, dtype=numpy_dtype),
-        np.full((10, 1), 2, dtype=numpy_dtype))
-
-
-    viewA = pk.View([10], pk_dtype)
-    viewB = pk.View([10, 1], pk_dtype)
-    viewA[:] = np.arange(10, dtype=numpy_dtype)
-    viewB[:] = np.full((10, 1), 2, dtype=numpy_dtype)
-
-    with pytest.raises(RuntimeError) as e_info:
-        viewC = pk.View([11], pk_dtype)
-        viewC[:] = np.arange(11, dtype=numpy_dtype)
-        pk_ufunc(viewC, viewB)
-
-    assert e_info.value.args[0] == "Input operand 1 has a mismatch in its core dimension (Size 11 is different from 10)"
-
-    actual = pk_ufunc(viewA, viewB)
-
-    assert_allclose(actual, expected)
-
-@pytest.mark.parametrize("arr", [
-    np.array([4, -1, np.inf]),
-    np.array([-np.inf, np.nan, np.inf]),
-])
-@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-        (pk.double, np.float64),
-        (pk.float, np.float32),
-])
-def test_1d_sqrt_negative_values(arr, pk_dtype, numpy_dtype):
-    # verify sqrt behavior for negative reals,
-    # NaN and infinite values
-    expected = np.sqrt(arr, dtype=numpy_dtype)
-    view: pk.View1d = pk.View([arr.size], pk_dtype)
-    view[:] = arr
-    actual = pk.sqrt(view=view)
-    assert_allclose(actual, expected)
-
-
-def test_caching():
-    # regression test for gh-34
-    expected = np.reciprocal(np.arange(10, dtype=np.float32))
-    for i in range(300):
-        view: pk.View1d = pk.View([10], pk.float)
-        view[:] = np.arange(10, dtype=np.float32)
-        actual = pk.reciprocal(view=view)
-        assert_allclose(actual, expected)
-
-
-@pytest.mark.parametrize("pk_ufunc, numpy_ufunc", [
-        (pk.reciprocal, np.reciprocal),
-])
-@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-        (pk.double, np.float64),
-        (pk.float, np.float32),
-])
-def test_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
-                                    numpy_ufunc,
-                                    pk_dtype,
-                                    numpy_dtype):
+def test_multi_array_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
+                                                numpy_ufunc,
+                                                pk_dtype,
+                                                numpy_dtype):
+    N = 4
+    M = 7
     rng = default_rng(123)
-    in_arr = rng.random((5, 5)).astype(numpy_dtype)
-    expected = numpy_ufunc(in_arr)
+    np1 = rng.random((N, M)).astype(numpy_dtype)
+    np2 = rng.random((N, M)).astype(numpy_dtype)
+    expected = numpy_ufunc(np1, np2)
 
-    view: pk.View2d = pk.View([5, 5], pk_dtype)
-    view[:] = in_arr
-    actual = pk_ufunc(view=view)
+    view1 = pk.array(np1)
+    view2 = pk.array(np2)
+    actual = pk_ufunc(viewA=view1, viewB=view2)
+
     assert_allclose(actual, expected)
 
+# @pytest.mark.parametrize("pk_dtype, numpy_dtype", [
+#         (pk.double, np.float64),
+#         (pk.float, np.float32),
+# ])
+# @pytest.mark.parametrize("in_arr", [
+#     np.array([-5, 4.5, np.nan]),
+#     np.array([np.nan, np.nan, np.nan]),
+# ])
+# def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
+#     in_arr = in_arr.astype(numpy_dtype)
+#     view: pk.View1D = pk.View([in_arr.size], pk_dtype)
+#     view[:] = in_arr
+#     expected = np.sign(in_arr)
+#     actual = pk.sign(view=view)
+#     assert_allclose(actual, expected)
 
-@pytest.mark.parametrize("pk_dtype, numpy_dtype", [
-        (pk.double, np.float64),
-        (pk.float, np.float32),
-])
-@pytest.mark.parametrize("in_arr", [
-    np.array([-5, 4.5, np.nan]),
-    np.array([np.nan, np.nan, np.nan]),
-])
-def test_sign_1d_special_cases(in_arr, pk_dtype, numpy_dtype):
-    in_arr = in_arr.astype(numpy_dtype)
-    view: pk.View1D = pk.View([in_arr.size], pk_dtype)
-    view[:] = in_arr
-    expected = np.sign(in_arr)
-    actual = pk.sign(view=view)
-    assert_allclose(actual, expected)
 
+# @pytest.mark.parametrize("input_dtype", [
+#         pk.double, pk.float,
+# ])
+# @pytest.mark.parametrize("pk_ufunc", [
+#         pk.floor,
+#         pk.round,
+#         pk.ceil,
+#         pk.trunc,
+# ])
+# @pytest.mark.parametrize("shape", [
+#         [1], [1, 1], [1, 1, 1],
+# ])
+# def test_rounding_dtype_preservation(input_dtype, pk_ufunc, shape):
+#     # at the time of writing the array API standard
+#     # conformance test suite doesn't appear to probe
+#     # floating point data types for many of the rounding
+#     # functions
 
-@pytest.mark.parametrize("input_dtype", [
-        pk.double, pk.float,
-])
-@pytest.mark.parametrize("pk_ufunc", [
-        pk.floor,
-        pk.round,
-        pk.ceil,
-        pk.trunc,
-])
-@pytest.mark.parametrize("shape", [
-        [1], [1, 1], [1, 1, 1],
-])
-def test_rounding_dtype_preservation(input_dtype, pk_ufunc, shape):
-    # at the time of writing the array API standard
-    # conformance test suite doesn't appear to probe
-    # floating point data types for many of the rounding
-    # functions
-
-    # for now, we simply test data type preservation
-    # of output vs. input so that we flush these codepaths
-    # a bit
-    view = pk.View(shape, input_dtype)
-    actual_dtype = pk_ufunc(view).dtype
-    assert actual_dtype.value == input_dtype.value
+#     # for now, we simply test data type preservation
+#     # of output vs. input so that we flush these codepaths
+#     # a bit
+#     view = pk.View(shape, input_dtype)
+#     actual_dtype = pk_ufunc(view).dtype
+#     assert actual_dtype.value == input_dtype.value

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -373,7 +373,7 @@ def test_multi_array_1d_exposed_ufuncs_vs_numpy(pk_ufunc,
     viewB: pk.View1d = pk.View([10], pk_dtype)
     viewB[:] = np.full(10, 5, dtype=numpy_dtype)
 
-    actual = pk_ufunc(viewA=viewA, viewB=viewB)
+    actual = pk_ufunc(viewA, viewB)
 
     assert_allclose(actual, expected)
 
@@ -479,7 +479,7 @@ def test_multi_array_2d_exposed_ufuncs_vs_numpy(pk_ufunc,
 
     view1 = pk.array(np1)
     view2 = pk.array(np2)
-    actual = pk_ufunc(viewA=view1, viewB=view2)
+    actual = pk_ufunc(view1, view2)
 
     assert_allclose(actual, expected)
 


### PR DESCRIPTION
`ufuncs.py`
  [+] Adding support for 2D views for the subtract util.
  [+] Added support for broadcasting views from scalar uptil 2D and anything inbetween (1D)

`pykokkos/__init__.py`
  [+] `broadcast_view(view_or_val, ontoThisView)` is an exposed utility

`test_ufuncs.py`
  [+] Added tests for subtract up til 2D -- these trigger broadcast too
  [-] Removed annotations in some test kernels to support scalars and views together