### PR TITLE
Use __restrict__ instead of Kokkos restrict macro

### DIFF
--- a/pykokkos/core/optimizations/restrict_views.py
+++ b/pykokkos/core/optimizations/restrict_views.py
@@ -111,7 +111,7 @@ def get_restrict_ptr_type(view_type: str) -> Tuple[cppast.ClassType, int]:
     rank: int = view_dtype.count("*")
 
     # Replace "**" with "*"
-    restrict_type: str = view_dtype.replace(rank * "*", "*") + " KOKKOS_RESTRICT"
+    restrict_type: str = view_dtype.replace(rank * "*", "*") + " __restrict__"
     decltype = cppast.ClassType(restrict_type)
 
     return decltype, rank


### PR DESCRIPTION
`__restrict__` seems to be supported with GCC, Clang, and NVCC and so is more reliable