### PR TITLE
Fix issue where using a docstring in a workunit or kokkos function caused a translation error

### DIFF
--- a/pykokkos/core/visitors/pykokkos_visitor.py
+++ b/pykokkos/core/visitors/pykokkos_visitor.py
@@ -499,6 +499,10 @@ class PyKokkosVisitor(ast.NodeVisitor):
         self.generic_error(node)  # TODO: test if possible
 
     def visit_Expr(self, node: ast.Expr) -> cppast.CallStmt:
+        # This is needed for docstrings
+        if isinstance(node.value, ast.Constant):
+            return cppast.EmptyStmt()
+
         if not isinstance(node.value, ast.Call):
             self.error(
                 node, "Only function calls are allowed as standalone statements")

--- a/tests/test_AST_translator.py
+++ b/tests/test_AST_translator.py
@@ -115,6 +115,12 @@ class ASTTestReduceFunctor:
         pass
 
     @pk.workunit
+    def docstring(self, tid: int) -> None:
+        """
+        Test docstring
+        """
+
+    @pk.workunit
     def call(self, tid: int, acc: pk.Acc[pk.double]) -> None:
         pk.printf("Testing printf: %d\n", self.i_1)
         acc += abs(- self.i_1)


### PR DESCRIPTION
Fixed by returning an empty statement when a standalone constant expression is encountered. Also added a test.