### PR TITLE
Tests: account for numpy 2.0 when testing uint views

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -382,9 +382,13 @@ def test_asarray_consts_vs_numpy(const, np_dtype, pk_dtype):
 def test_unsigned_int_overflow(pk_dtype, np_dtype):
     # test for gh-86
     actual = pk.View([1], dtype=pk_dtype)
-    actual[:] = -1
-    expected = np.array(-1, dtype=np_dtype)
-    assert_equal(actual, expected)
+    if np.__version__.startswith("2."):
+        with pytest.raises(OverflowError):
+            actual[:] = -1
+    else:
+        actual[:] = -1
+        expected = np.array(-1, dtype=np_dtype)
+        assert_equal(actual, expected)
 
 
 @pytest.mark.parametrize("pk_dtype, pk_dtype2, expected_promo", [


### PR DESCRIPTION
In NumPy 2.0, assigning negative values to arrays of unsigned integers raises an `OverflowError`. This PR modifies the test to account for this change in behavior so our tests pass again. In the future we should decide whether we should follow numpy more closely or keep the old behavior.