### PR TITLE
Fix TeamPolicy constructor docstring.

### DIFF
--- a/pykokkos/interface/execution_policy.py
+++ b/pykokkos/interface/execution_policy.py
@@ -120,8 +120,8 @@ class TeamPolicy(ExecutionPolicy):
             :param space: (optional) a string or
                 ExecutionSpaceInstance object. If not specified, default
                 is used
-            :param begin: the tid of the first thread
-            :param end: the total number of threads
+            :param league_size: the total number of teams
+            :param team_size: the number of threads per team
         """
 
         unpacked: Tuple = tuple(args)


### PR DESCRIPTION
TeamPolicy constructor docstring incorrectly copy and pasted from RangePolicy constructor. Update to reflect true description of league size and team size.