### PR TITLE
Interface: add cyl_bessel_j0 and cyl_bessel_j1 as mathemtical functions

### DIFF
--- a/pykokkos/core/visitors/workunit_visitor.py
+++ b/pykokkos/core/visitors/workunit_visitor.py
@@ -307,6 +307,17 @@ class WorkunitVisitor(PyKokkosVisitor):
 
             return rand_call
 
+        if name in {"cyl_bessel_j0", "cyl_bessel_j1"}:
+            if len(args) != 1:
+                self.error(node, "pk.cyl_bessel_j0/j1 accepts only one argument")
+
+            s = cppast.Serializer()
+            arg_str = s.serialize(args[0])
+            math_call = cppast.CallExpr(cppast.DeclRefExpr(f"Kokkos::Experimental::{name}<Kokkos::complex<decltype({arg_str})>, double, int>"), args)
+            real_number_call = cppast.MemberCallExpr(math_call, cppast.DeclRefExpr("real"), [])
+
+            return real_number_call
+
         return super().visit_Call(node)
 
     def is_nested_call(self, node: ast.FunctionDef) -> bool:

--- a/pykokkos/interface/__init__.py
+++ b/pykokkos/interface/__init__.py
@@ -32,6 +32,9 @@ from .layout import Layout, get_default_layout
 from .hierarchical import (
     AUTO, TeamMember, PerTeam, PerThread, single
 )
+from .mathematical_special_functions import (
+    cyl_bessel_j0, cyl_bessel_j1
+)
 from .memory_space import MemorySpace, get_default_memory_space
 from .parallel_dispatch import (
     execute, flush,

--- a/pykokkos/interface/mathematical_special_functions.py
+++ b/pykokkos/interface/mathematical_special_functions.py
@@ -1,0 +1,6 @@
+
+def cyl_bessel_j0(input: float) -> float:
+    pass
+
+def cyl_bessel_j1(input: float) -> float:
+    pass


### PR DESCRIPTION
These functions accept and return complex numbers. Since we have not implemented `Kokkos::complex` yet in pykokkos, the current implementation only accepts and returns real numbers.