### PR TITLE
Tracer: fix caching issue and detect views passed to function calls

### DIFF
--- a/pykokkos/core/fusion/access_modes.py
+++ b/pykokkos/core/fusion/access_modes.py
@@ -114,9 +114,10 @@ class WriteIndicesVisitor(ast.NodeVisitor):
         # Treat function calls like a black box
         for arg in node.args:
             if not isinstance(arg, ast.Name):
-                continue
+                self.visit(arg)
 
-            if arg.id in self.view_args:
+            # If an entire view is passed to a function
+            elif arg.id in self.view_args:
                 rank: int = self.view_args[arg.id]
                 for i in range(rank):
                     self.access_indices[(arg.id, i)] = (AccessIndex.All, AccessMode.ReadWrite, "")


### PR DESCRIPTION
This includes a cache issue where multiple calls to the same workunit with different arguments were getting the same view access information. Another issue was that view elements passed to function calls were not being detected properly.