### PR TITLE
Tracer: fix issue with not detecting view access modes when they are used as a subscript in another view index

### DIFF
--- a/pykokkos/core/fusion/access_modes.py
+++ b/pykokkos/core/fusion/access_modes.py
@@ -132,6 +132,10 @@ class WriteIndicesVisitor(ast.NodeVisitor):
             slices.insert(0, index)
             current_node = current_node.value
 
+        # The subscript itself could be indexing another view
+        for s in slices:
+            self.visit(s)
+
         # Avoid type annotations
         if isinstance(current_node, ast.Attribute):
             return


### PR DESCRIPTION
This pattern occurs in gups.py, e.g.
```python
data[indices[i]]
```
This fix makes sure we detect that the workunit is reading from indices