### PR TITLE
Optimizations: fix indexing of restrict views adding extra operations

### DIFF
--- a/pykokkos/core/visitors/pykokkos_visitor.py
+++ b/pykokkos/core/visitors/pykokkos_visitor.py
@@ -270,7 +270,11 @@ class PyKokkosVisitor(ast.NodeVisitor):
             unfused_name: str = r.group(1) if r else ref.declname
 
             if "PK_RESTRICT" in os.environ and unfused_name in self.restrict_views or name in self.restrict_views:
-                subscript = index_restrict_view(ref, args)
+                if unfused_name in self.restrict_views:
+                    v = self.restrict_views[unfused_name]
+                else:
+                    v = self.restrict_views[name]
+                subscript = index_restrict_view(ref, args, v)
             else:
                 subscript = cppast.CallExpr(ref, args)
 


### PR DESCRIPTION
This removes an extra multiply for indexing 1D and LayoutLeft/LayoutRight 2D views since we know that one of their strides is 1. 