### PR TITLE
install: add installation tip, related to `ninja` system

### DIFF
--- a/installation.html
+++ b/installation.html
@@ -148,6 +148,20 @@ install <code class="docutils literal notranslate"><span class="pre">pykokkos-ba
 <div class="highlight-bash notranslate"><div class="highlight"><pre><span></span>python<span class="w"> </span>setup.py<span class="w"> </span>install<span class="w"> </span>--<span class="w"> </span>-DENABLE_LAYOUTS<span class="o">=</span>ON<span class="w"> </span>-DENABLE_MEMORY_TRAITS<span class="o">=</span>OFF<span class="w"> </span>-DENABLE_VIEW_RANKS<span class="o">=</span><span class="m">3</span><span class="w"> </span>-DENABLE_CUDA<span class="o">=</span>ON<span class="w"> </span>-DENABLE_THREADS<span class="o">=</span>OFF<span class="w"> </span>-DENABLE_OPENMP<span class="o">=</span>ON
 </pre></div>
 </div>
+<div>
+<p>If <code class="docutils literal notranslate"><span
+class="pre">ninja</span></code> is installed on your system and you encountered
+system freezes or system crashes during <code class="docutils literal
+notranslate"><span class="pre">pykokkos-base</span></code> compilation process,
+try assigning fewer threads to the compilation by setting cmake variable:
+
+<div class="highlight-bash notranslate"><div class="highlight"><pre><span></span><span class="nb">export</span><span class="w"> </span><span class="nv">CMAKE_BUILD_PARALLEL_LEVEL</span><span class="o">=</span>X</pre>
+</div></div>
+
+variable, where <code class="docutils literal notranslate"><span
+class="pre">X</NUM></span></code> is a number of assigned processors.
+</p></div>
+
 <p>Other <code class="docutils literal notranslate"><span class="pre">pykokkos-base</span></code> configuration and installation options can be
 found in that project’s <a class="reference external" href="https://github.com/kokkos/pykokkos-base/blob/main/README.md">README</a>.  Note
 that this step will compile a large number of bindings which can take


### PR DESCRIPTION
Duplicate of https://github.com/kokkos/pykokkos-base/pull/66 issue

The compilation stage loads the machine heavily, which can cause system crashes.

It was tested on the following machines, and confirmed that the ninja causes this error:

```
OS: Pop!_OS 22.04 LTS x86_64
Kernel: 6.16.3-76061603-generic
CPU: AMD Ryzen 5 5600H (12) @ 4.280G
GPU: NVIDIA GeForce RTX 3050 Ti Mobile
Memory: 16GB
```
```
OS: Ubuntu 22.04.4 LTS x86_64
Kernel: 6.14.0-32-generic
CPU: Intel Xeon w5-3433 (32) @ 4.000GHz
GPU: NVIDIA ac:00.0 NVIDIA Corporation Device 26b2
GPU: NVIDIA ac:00.0 NVIDIA Corporation Device 26b2
Memory: 128GB
```