### PR TITLE
workflows: updated github workflows

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -30,7 +30,7 @@ jobs:
           cd /tmp
           git clone https://github.com/kokkos/pykokkos-base.git
           cd pykokkos-base
-          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=5
+          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=5 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - name: Install pykokkos
         run: |
           python -m pip install .

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -30,7 +30,7 @@ jobs:
           cd /tmp
           git clone https://github.com/kokkos/pykokkos-base.git
           cd pykokkos-base
-          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=5
+          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=5 -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - name: Install pykokkos
         run: |
           python -m pip install .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
           cd /tmp
           git clone https://github.com/kokkos/pykokkos-base.git
           cd pykokkos-base
-          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DKokkos_DIR=/tmp/kokkos_install/lib/cmake/Kokkos/ -DENABLE_INTERNAL_KOKKOS=OFF
+          python setup.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DKokkos_DIR=/tmp/kokkos_install/lib/cmake/Kokkos/ -DENABLE_INTERNAL_KOKKOS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5
       - name: Install pykokkos
         run: |
           python -m pip install .


### PR DESCRIPTION
 add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5 due to pybind11 cmakelist versioning errors
Without this flag, PyKokkos can not be compiler and will throw an error