### PR TITLE
fmt: fix

### DIFF
--- a/pykokkos/core/translators/symbols_pass.py
+++ b/pykokkos/core/translators/symbols_pass.py
@@ -64,7 +64,9 @@ class SymbolsPass:
         self.global_symbols.update(math_functions)
         self.global_symbols.update(allowed_types)
         self.global_symbols.update(view_dtypes)
-        self.global_symbols.update(["self", "range", "math", "List", "abs", "inclusive_scan"])
+        self.global_symbols.update(
+            ["self", "range", "math", "List", "abs", "inclusive_scan"]
+        )
         self.global_symbols.add(pk_import)
 
         self.global_symbols.update([field.declname for field in members.fields])


### PR DESCRIPTION
https://github.com/kokkos/pykokkos/pull/319/checks
These workflows had no fails since previous PR (https://github.com/kokkos/pykokkos/pull/319) were created **before** we introduced formatting CI (https://github.com/kokkos/pykokkos/pull/336)

All CIs before https://github.com/kokkos/pykokkos/pull/336 should be manually synchronized with `main` branch or check formatting manually with `black --diff --check .` 