### PR TITLE
CI: pin tool versions

### DIFF
--- a/.github/workflows/base-python-package.yml
+++ b/.github/workflows/base-python-package.yml
@@ -35,7 +35,7 @@ jobs:
         miniforge-version: "latest"
         architecture: ${{ contains(matrix.os, 'arm') && 'arm64' || 'x64' }}
     - name: Install flake8
-      run: conda install -c conda-forge flake8
+      run: conda install -c conda-forge flake8=7.3.0
     - name: Lint with flake8
       working-directory: base
       run: |


### PR DESCRIPTION
Recent CI run showed that we still have a missing `black` tool version (we tried to install the most recent one)
This PR pins the latest stable version for `black` and `flake8`, so we don't need to reformat our code every time the published releases a new version (e.g., `black` publishes a new release every month)