### PR TITLE
examples: kokkos examples conversion (workload to workunit)

### DIFF
--- a/examples/kokkos/01_hello_world.py
+++ b/examples/kokkos/01_hello_world.py
@@ -1,13 +1,16 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def hello(i: int):
     pk.printf("Hello from i = %d\n", i)
+
 
 def main():
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
     pk.parallel_for(N, hello)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/02_simple_reduce.py
+++ b/examples/kokkos/02_simple_reduce.py
@@ -1,20 +1,23 @@
 import numpy as np
 import pykokkos as pk
 
+
 @pk.workunit
 def squaresum(i: int, acc, values):
     acc += values[i]
 
+
 def main():
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     # Create array with squares
     values = np.array([i * i for i in range(N)], dtype=np.int32)
-    
+
     total = pk.parallel_reduce(N, squaresum, values=values)
-    
+
     print("Sum:", total)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/03_simple_view.py
+++ b/examples/kokkos/03_simple_view.py
@@ -1,26 +1,30 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def initialize_view(i: int, a: pk.View2D[pk.int32]):
     for j in range(3):
         a[i][j] = (i + 1) ** (j + 1)
 
+
 @pk.workunit
 def my_reduction(i: int, accumulator: pk.Acc[pk.double], a: pk.View2D[pk.int32]):
     accumulator += a[i][0] * a[i][1] / (a[i][2])
 
+
 def main():
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     a: pk.View2D[pk.int32] = pk.View([N, 3], pk.int32)
-    
+
     pk.parallel_for(N, initialize_view, a=a)
     total: int = pk.parallel_reduce(N, my_reduction, a=a)
-    
+
     for row in a:
         print(row)
     print("\nResult is", total)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/04_simple_memoryspaces.py
+++ b/examples/kokkos/04_simple_memoryspaces.py
@@ -1,23 +1,26 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def reduction(i: int, acc: pk.Acc[pk.double], a: pk.View2D[pk.int32]):
     acc += a[i][0] - a[i][1] + a[i][2]
 
+
 def main():
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     a: pk.View2D[pk.int32] = pk.View([N, 3], pk.int32)
-    
+
     # Initialize the view
     for i in range(N):
         for j in range(3):
             a[i][j] = i * N + j
-    
+
     sum_result: int = pk.parallel_reduce(N, reduction, a=a)
-    
+
     print(sum_result)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/05_simple_atomics.py
+++ b/examples/kokkos/05_simple_atomics.py
@@ -2,45 +2,51 @@ import math
 import random
 import pykokkos as pk
 
+
 @pk.workunit
-def findprimes(i: int, data: pk.View1D[pk.int32], result: pk.View1D[pk.int32], count: pk.View1D[pk.int32]):
+def findprimes(
+    i: int,
+    data: pk.View1D[pk.int32],
+    result: pk.View1D[pk.int32],
+    count: pk.View1D[pk.int32],
+):
     number: int = data[i]
     upper_bound: int = int(math.sqrt(number)) + 1
     is_prime: bool = not (number % 2 == 0)
     k: int = 3
     idx: int = 0
-    
+
     while k < upper_bound and is_prime:
         is_prime = not (number % k == 0)
         k += 2
-    
+
     if is_prime:
         # Note: This atomic operation may have race conditions without proper atomic support
         # For now, we remove the atomic trait as it's not supported
         idx = count[0] = count[0] + 1
         result[idx - 1] = number
 
+
 def simple_atomics():
     N: int = 100
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     data: pk.View1D[pk.int32] = pk.View([N], pk.int32)
     result: pk.View1D[pk.int32] = pk.View([N], pk.int32)
     # FIXED: Removed trait=pk.Trait.Atomic as it's not supported
     count: pk.View1D[pk.int32] = pk.View([1], pk.int32)
-    
+
     # Initialize data with random numbers
     for i in range(N):
         data[i] = random.randint(0, N)
-    
+
     pk.parallel_for(N, findprimes, data=data, result=result, count=count)
-    
+
     # Print results
     for i in range(int(count[0])):
         print(int(result[i]), end=", ")
-    print(
-        "\nFound", int(count[0]), "prime numbers in", N, "random numbers"
-    )
+    print("\nFound", int(count[0]), "prime numbers in", N, "random numbers")
+
 
 if __name__ == "__main__":
     simple_atomics()

--- a/examples/kokkos/add1.py
+++ b/examples/kokkos/add1.py
@@ -1,24 +1,27 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def add1(i: int, a: pk.View1D[pk.int32]):
     a[i] += 1
+
 
 def main():
     n: int = 100 * 1000
     N: int = n
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     a: pk.View1D[pk.int32] = pk.View([N], pk.int32)
-    
+
     # Initialize the view
     for i in range(N):
         a[i] = 2
     print(f"Initialized view: [{a[0]}, ... repeats {n-1} times]")
-    
+
     pk.parallel_for(N, add1, a=a)
-    
+
     print(f"Results: [{a[0]}, ... repeats {n-1} times]")
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/math_functions.py
+++ b/examples/kokkos/math_functions.py
@@ -1,28 +1,29 @@
 import math
 import pykokkos as pk
 
+
 @pk.workunit
 def my_calculation(i: int, a: pk.View1D[pk.int32], N: int):
     pk.printf("Running index %d\n", i)
-    a[i] += (
-        math.cos(a[i]) + 2**i - math.pi / math.fabs(a[(i + 1) % N])
-    )
+    a[i] += math.cos(a[i]) + 2**i - math.pi / math.fabs(a[(i + 1) % N])
+
 
 def main():
     n: int = 10
     N: int = n
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     a: pk.View1D[pk.int32] = pk.View([N], pk.int32)
-    
+
     # Initialize the view
     for i in range(N):
         a[i] = math.sqrt(math.tau)
     print("Initialized view:", a)
-    
+
     pk.parallel_for(N, my_calculation, a=a, N=N)
-    
+
     print("Results: ", a)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/matrix_sum.py
+++ b/examples/kokkos/matrix_sum.py
@@ -1,33 +1,37 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def sum_row(i: int, mat: pk.View2D[pk.int32], c: int):
     for j in range(1, c):
         mat[i][0] += mat[i][j]
 
+
 @pk.workunit
 def final_sum(i: int, accumulator: pk.Acc[pk.double], mat: pk.View2D[pk.int32]):
     accumulator += mat[i][0]
+
 
 def main():
     r: int = 5
     c: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     mat: pk.View2D[pk.int32] = pk.View([r, c], pk.int32)
-    
+
     # Initialize the matrix
     for i in range(r):
         mat[i] = list(range(c * i, c * (i + 1)))
-    
+
     for row in mat:
         print(row)
     print(f"Initialized {r}x{c} array")
-    
+
     pk.parallel_for(r, sum_row, mat=mat, c=c)
     total: int = pk.parallel_reduce(r, final_sum, mat=mat)
-    
+
     print("Total =", total)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/random_sum.py
+++ b/examples/kokkos/random_sum.py
@@ -1,25 +1,28 @@
 import random
 import pykokkos as pk
 
+
 @pk.workunit
 def my_reduction(i: int, accumulator: pk.Acc[pk.int32], a: pk.View1D[pk.int32]):
     accumulator += a[i]
+
 
 def main():
     n: int = 10
     N: int = n
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     a: pk.View1D[pk.int32] = pk.View([N], pk.int32)
-    
+
     # Initialize the view with random values
     for i in range(N):
         a[i] = random.randint(0, 10)
     print("Initialized view:", a)
-    
+
     total: int = pk.parallel_reduce(N, my_reduction, a=a)
-    
+
     print("Sum:", total)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/kokkos/scan_functor.py
+++ b/examples/kokkos/scan_functor.py
@@ -1,8 +1,10 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def init(i: int, A: pk.View1D[pk.int32]):
     A[i] = i
+
 
 @pk.workunit
 def scan(i: int, acc: pk.Acc[pk.double], last_pass: bool, A: pk.View1D[pk.int32]):
@@ -10,21 +12,23 @@ def scan(i: int, acc: pk.Acc[pk.double], last_pass: bool, A: pk.View1D[pk.int32]
     if last_pass:
         A[i] = acc
 
+
 def run() -> None:
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     A: pk.View1D[pk.int32] = pk.View([N], pk.int32)
-    
+
     p = pk.RangePolicy(pk.ExecutionSpace.OpenMP, 0, N)
-    
+
     pk.parallel_for(p, init, A=A)
-    
+
     timer = pk.Timer()
     result = pk.parallel_scan(p, scan, A=A)
     timer_result = timer.seconds()
-    
+
     print(f"{A} total={result} time({timer_result})")
+
 
 if __name__ == "__main__":
     run()

--- a/examples/kokkos/scan_workload.py
+++ b/examples/kokkos/scan_workload.py
@@ -1,8 +1,10 @@
 import pykokkos as pk
 
+
 @pk.workunit
 def init(i: int, A: pk.View1D[pk.int32]):
     A[i] = i
+
 
 @pk.workunit
 def scan(i: int, acc: pk.Acc[pk.double], last_pass: bool, A: pk.View1D[pk.int32]):
@@ -10,19 +12,21 @@ def scan(i: int, acc: pk.Acc[pk.double], last_pass: bool, A: pk.View1D[pk.int32]
     if last_pass:
         A[i] = acc
 
+
 def run() -> None:
     N: int = 10
     pk.set_default_space(pk.ExecutionSpace.OpenMP)
-    
+
     A: pk.View1D[pk.int32] = pk.View([N], pk.int32)
-    
+
     pk.parallel_for(N, init, A=A)
-    
+
     timer = pk.Timer()
     result: int = pk.parallel_scan(N, scan, A=A)
     timer_result: float = timer.seconds()
-    
+
     print(f"{A} total={result} time({timer_result})")
+
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
Converts all examples in examples/kokkos/ from the deprecated workload/functor style to the modern standalone style as requested in issue #351 (part of the broader deprecation effort #326).