### PR TITLE
workflows: remove `ubuntu 22.04` from CIs

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -12,7 +12,7 @@ jobs:
   test_array_api:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
         python-version: [3.11, 3.12, 3.13]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/base-cancelling.yml
+++ b/.github/workflows/base-cancelling.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Cancel duplicate workflow runs"
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/base-linux-ci.yml
+++ b/.github/workflows/base-linux-ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         python-version: [3.11, 3.12, 3.13]
         kokkos-branch: ['4.7.01']
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
 
     runs-on: ${{matrix.os}}
     defaults:

--- a/.github/workflows/base-python-package.yml
+++ b/.github/workflows/base-python-package.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11, 3.12, 3.13]
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
 
     runs-on: ${{matrix.os}}
     defaults:
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.13]
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
 
     runs-on: ${{matrix.os}}
     defaults:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.13]
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest]
 
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -12,7 +12,7 @@ jobs:
   test_pykokkos:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
         python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
   test_vs_kokkos_develop:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm]
+        os: [ubuntu-latest, ubuntu-22.04-arm]
         python-version: ["3.13"]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
We found out that we dont need so many Ubuntu versions to test our code, and especially don't need so many versions to check formatting