### PR TITLE
core: update to kokkos 5.0.02 update

### DIFF
--- a/.github/workflows/base-linux-ci.yml
+++ b/.github/workflows/base-linux-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11, 3.12, 3.13]
-        kokkos-branch: ['4.7.01']
+        kokkos-branch: ['5.0.2']
         os: [ubuntu-latest, ubuntu-22.04-arm]
 
     runs-on: ${{matrix.os}}
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.11, 3.12, 3.13]
-        kokkos-branch: ['4.7.01']
+        kokkos-branch: ['5.0.2']
         os: [ubuntu-latest]
 
     runs-on: ${{matrix.os}}

--- a/base/cmake/Modules/KokkosPythonKokkos.cmake
+++ b/base/cmake/Modules/KokkosPythonKokkos.cmake
@@ -167,8 +167,8 @@ IF(_INTERNAL_KOKKOS)
         MESSAGE(STATUS "Fetching Kokkos via FetchContent")
         FETCHCONTENT_DECLARE(
           Kokkos
-          URL https://github.com/kokkos/kokkos/releases/download/4.7.01/kokkos-4.7.01.zip
-          URL_HASH SHA256=2b7c9964ace4245dec0b952932873d4b1235933dbb7d8d1d69e17b4368784503
+          URL https://github.com/kokkos/kokkos/releases/download/5.0.2/kokkos-5.0.2.zip
+          URL_HASH SHA256=c4ec42b952a0c8474d370cf0aac025adeed81326c78c23ecdfc98c18818a575a
         )
         FETCHCONTENT_MAKEAVAILABLE(Kokkos)
         FETCHCONTENT_GETPROPERTIES(Kokkos SOURCE_DIR Kokkos_SOURCE_DIR)

--- a/base/cmake/Modules/KokkosPythonKokkos.cmake
+++ b/base/cmake/Modules/KokkosPythonKokkos.cmake
@@ -154,6 +154,10 @@ IF(_INTERNAL_KOKKOS)
         ADD_OPTION(Kokkos_ENABLE_CUDA "Build Kokkos submodule with CUDA support" ON)
         ADD_OPTION(Kokkos_ENABLE_CUDA_UVM "Build Kokkos submodule with CUDA UVM support" ON)
         ADD_OPTION(Kokkos_ENABLE_CUDA_LAMBDA "Build Kokkos submodule with CUDA lambda support" ON)
+        # Kokkos 5+ requires DEPRECATED_CODE_4 to use CUDA UVM (UVM is deprecated in favor of SharedSpace)
+        IF(Kokkos_ENABLE_CUDA_UVM)
+            SET(Kokkos_ENABLE_DEPRECATED_CODE_4 ON CACHE BOOL "Required for Kokkos_ENABLE_CUDA_UVM in Kokkos 5+" FORCE)
+        ENDIF()
     ENDIF()
 
     # Check if we should use submodule or FetchContent

--- a/base/cmake/Modules/KokkosPythonOptions.cmake
+++ b/base/cmake/Modules/KokkosPythonOptions.cmake
@@ -84,7 +84,7 @@ set(CMAKE_C_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
 set(CMAKE_CXX_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
 
 # pybind11 has not migrated to CMAKE_CXX_STANDARD and neither has kokkos
-SET(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ language standard")
+SET(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ language standard")
 SET(CMAKE_CXX_STANDARD_REQUIRED ON CACHE BOOL "Require standard")
 SET(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Extensions")
 IF(NOT Kokkos_CXX_STANDARD)

--- a/base/setup.py
+++ b/base/setup.py
@@ -68,10 +68,10 @@ add_arg_bool_option("werror", "ENABLE_WERROR")
 add_arg_bool_option("timing", "ENABLE_TIMING")
 parser.add_argument(
     "--cxx-standard",
-    default=17,
+    default=20,
     type=int,
     choices=[14, 17, 20],
-    help="Set C++ language standard",
+    help="Set C++ language standard (Kokkos 5+ requires C++20)",
 )
 parser.add_argument(
     "--enable-view-ranks",

--- a/pykokkos/core/CMakeLists.txt
+++ b/pykokkos/core/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 # Dependencies
 find_package(pybind11 2.11 CONFIG REQUIRED)
-find_package(Kokkos 4.7.1 EXACT REQUIRED)
+find_package(Kokkos 5.0.2 EXACT REQUIRED)
 
 # Sources and targets
 file(GLOB SOURCE_FILES "*.cpp")


### PR DESCRIPTION
This PR updates the Kokkos version from 4.7.01 to 5.0.02