### PR TITLE
core: binding fix

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -172,7 +172,7 @@ class Compiler:
         }:
             raise Exception(f"Types are required for style: {entity.style}")
 
-        if self.is_compiled(module_setup.output_dir):
+        if self.is_compiled(module_setup.output_dir) and module_setup.is_compiled():
             if hash not in self.members:  # True if pre-compiled
                 if len(metadata) > 1:
                     entity, classtypes = self.fuse_objects(

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -222,7 +222,9 @@ class CppSetup:
             view_layout_space = default_space if not is_host_execution_space(default_space) else space
         else:
             view_layout_space = space
-        view_layout: str = str(get_default_layout(get_default_memory_space(view_layout_space)))
+        view_layout: str = str(
+            get_default_layout(get_default_memory_space(view_layout_space))
+        )
         view_layout = view_layout.split(".")[-1]
         view_layout = f"Kokkos::{view_layout}"
 

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -219,7 +219,9 @@ class CppSetup:
         # layout must also match the caller's views (GPU = LayoutLeft)
         if is_host_execution_space(space):
             default_space = km.get_default_space()
-            view_layout_space = default_space if not is_host_execution_space(default_space) else space
+            view_layout_space = (
+                default_space if not is_host_execution_space(default_space) else space
+            )
         else:
             view_layout_space = space
         view_layout: str = str(

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -201,13 +201,28 @@ class CppSetup:
             if enable_uvm:
                 view_space = "Kokkos::Experimental::HIPManagedSpace"
 
+        # kernel compiled for host but default space is device
+        # in this case we need to convert them a bit
+        if is_host_execution_space(space):
+            default_space: ExecutionSpace = km.get_default_space()
+            if not is_host_execution_space(default_space):
+                ns = get_default_memory_space(default_space).name
+                prefix = "Kokkos::Experimental" if "HIP" in ns else "Kokkos"
+                view_space = f"{prefix}::{ns}"
+
         space_value: str
         if space.value == "HIP":
             space_value = "Experimental::HIP"
         else:
             space_value = space.value
 
-        view_layout: str = str(get_default_layout(get_default_memory_space(space)))
+        # layout must also match the caller's views (GPU = LayoutLeft)
+        if is_host_execution_space(space):
+            default_space = km.get_default_space()
+            view_layout_space = default_space if not is_host_execution_space(default_space) else space
+        else:
+            view_layout_space = space
+        view_layout: str = str(get_default_layout(get_default_memory_space(view_layout_space)))
         view_layout = view_layout.split(".")[-1]
         view_layout = f"Kokkos::{view_layout}"
 

--- a/pykokkos/core/fusion/fuse.py
+++ b/pykokkos/core/fusion/fuse.py
@@ -1,5 +1,4 @@
 import ast
-import os
 from typing import Any, Dict, List, Set, Tuple, Union
 
 from .util import DeclarationsVisitor, VariableRenamer
@@ -47,7 +46,7 @@ def fuse_workunit_kwargs_and_params(
 
         for p in current_params:
             current_arg = current_kwargs[p.arg]
-            if "PK_FUSE_ARGS" in os.environ and id(current_arg) in view_ids:
+            if id(current_arg) in view_ids:
                 continue
 
             view_ids.add(id(current_arg))
@@ -131,7 +130,7 @@ def fuse_arguments(
                 continue
 
             current_arg = current_kwargs[old_name]
-            if "PK_FUSE_ARGS" in os.environ and id(current_arg) in fused_view_names:
+            if id(current_arg) in fused_view_names:
                 name_map[key] = fused_view_names[id(current_arg)]
                 continue
 

--- a/pykokkos/core/keywords.py
+++ b/pykokkos/core/keywords.py
@@ -14,6 +14,7 @@ class Keywords(Enum):
     ThreadsBegin = "pk_threads_begin"
     ThreadsEnd = "pk_threads_end"
     ArgMemSpace = "pk_arg_memspace"
+    ArgLayout = "pk_arg_layout"
     DefaultExecSpace = "pk_exec_space"
     DefaultExecSpaceInstance = "pk_exec_space_instance"
     KernelName = "pk_kernel_name"

--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -8,6 +8,7 @@ import sysconfig
 from typing import Callable, List, Optional, Set, Union
 
 from pykokkos.interface import ExecutionSpace
+from pykokkos.interface.execution_space import is_host_execution_space
 import pykokkos.kokkos_manager as km
 
 from .cpp_setup import CppSetup
@@ -181,7 +182,17 @@ class ModuleSetup:
         if restrict_signature is not None:
             out_dir = out_dir / f"restrict_{restrict_signature}"
 
-        out_dir = out_dir / space.value
+        # special case:
+        # default space is device (all contexts are GPU-sided), but the kernel
+        # call is from host need to handle this differently, because
+        # `pk_arg_memspace/pk_arg_layout`s are GPU-oriented!!
+        dir_name: str = space.value
+        if is_host_execution_space(space):
+            default_space: ExecutionSpace = km.get_default_space()
+            if not is_host_execution_space(default_space):
+                dir_name = f"{space.value}_caller_{default_space.value}"
+
+        out_dir = out_dir / dir_name
 
         return out_dir
 
@@ -250,15 +261,19 @@ class ModuleSetup:
 
     def is_compiled(self) -> bool:
         """
-        Check if this module is compiled for its execution space
+        Check if this module is compiled for its execution space.
+        Verifies the actual .so file exists, not just the directory, so that
+        a failed compilation (which leaves the directory but no .so) is
+        correctly detected as not-yet-compiled and retried.
         """
 
-        return CppSetup.is_compiled(
-            self.get_output_dir(
-                self.main,
-                self.metadata,
-                self.space,
-                self.types_signature,
-                self.restrict_signature,
-            )
+        output_dir: Optional[Path] = self.get_output_dir(
+            self.main,
+            self.metadata,
+            self.space,
+            self.types_signature,
+            self.restrict_signature,
         )
+        if output_dir is None:
+            return False
+        return (output_dir / self.module_file).is_file()

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -82,7 +82,11 @@ def get_kernel_params(
             continue
 
         space: str = get_view_memory_space(t, "bindings")
-        layout: str = f"{Keywords.DefaultExecSpace.value}::array_layout"
+        # Use pk_arg_layout (set at compile time to match the caller's view
+        # layout) rather than pk_exec_space::array_layout.  This lets a host
+        # execution space (Serial, OpenMP) accept GPU-layout views from a Cuda
+        # caller; create_mirror_view_and_copy inside run_* handles the copy.
+        layout: str = Keywords.ArgLayout.value
         params[n.declname] = cpp_view_type(t, space=space, layout=layout, real=real)
 
     params[Keywords.DefaultExecSpaceInstance.value] = Keywords.DefaultExecSpace.value
@@ -139,6 +143,50 @@ def get_device_views(members: PyKokkosMembers) -> Dict[str, str]:
     }
 
 
+def _generate_mirror_with_exec_layout(
+    src: str,
+    dst: str,
+    view_type: cppast.ClassType,
+    exec_space_instance: str,
+    real: Optional[str],
+) -> str:
+    """
+    Generate C++ code that creates a properly-typed mirror view in the
+    execution space's native memory space AND layout, then deep-copies from
+    the source view.
+
+    Using Kokkos::create_mirror_view_and_copy is not sufficient here because
+    it preserves the source layout.  When a host execution space (Serial,
+    OpenMP) receives a GPU-allocated view (CudaUVMSpace / LayoutLeft), the
+    mirror would be LayoutLeft/HostSpace but the functor template expects
+    LayoutRight/HostSpace (ExecSpace::array_layout for Serial = LayoutRight).
+    Kokkos::deep_copy handles both the memory-space transfer and the
+    layout conversion in one call.
+    """
+    # Build the destination view type with the execution space's native
+    # memory space and array layout.
+    exec_space: str = Keywords.DefaultExecSpace.value
+    dst_type: str = cpp_view_type(
+        view_type,
+        space=f"{exec_space}::memory_space",
+        layout=f"{exec_space}::array_layout",
+        real=real,
+    )
+
+    # Determine rank to emit the right number of extent() calls.
+    typename: str = view_type.typename
+    match = re.search(r"(?:View|ScratchView)(\d+)D", typename)
+    rank: int = int(match.group(1)) if match else 1
+    extents: str = ",".join(f"{src}.extent({i})" for i in range(rank))
+
+    code: str = (
+        f'{dst_type} {dst}('
+        f'Kokkos::view_alloc("{dst}", Kokkos::WithoutInitializing), {extents});'
+        f"Kokkos::deep_copy({dst}, {src});"
+    )
+    return code
+
+
 def generate_functor_instance(
     functor: str,
     members: PyKokkosMembers,
@@ -180,11 +228,15 @@ def generate_functor_instance(
                 get_view_memory_space(view_type, "bindings")
                 == Keywords.ArgMemSpace.value
             ):
-                mirror_views += f"auto {d_v} = Kokkos::create_mirror_view_and_copy({exec_space_instance}, {v});"
+                mirror_views += _generate_mirror_with_exec_layout(
+                    v, d_v, view_type, exec_space_instance, None
+                )
             else:
                 mirror_views += f"auto {d_v} = {v};"
         else:
-            mirror_views += f"auto {d_v} = Kokkos::create_mirror_view_and_copy({exec_space_instance}, {v});"
+            mirror_views += _generate_mirror_with_exec_layout(
+                v, d_v, members.views[cppast.DeclRefExpr(v)], exec_space_instance, None
+            )
 
     # Kokkos fails to compile a functor if there are no parameters in its constructor
     if len(args) == 0:

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -1,5 +1,4 @@
 import sys
-import re
 from typing import Dict, List, Optional, Tuple
 
 from pykokkos.core import cppast
@@ -143,28 +142,19 @@ def get_device_views(members: PyKokkosMembers) -> Dict[str, str]:
     }
 
 
+
 def _generate_mirror_with_exec_layout(
     src: str,
     dst: str,
     view_type: cppast.ClassType,
-    exec_space_instance: str,
     real: Optional[str],
 ) -> str:
     """
     Generate C++ code that creates a properly-typed mirror view in the
     execution space's native memory space AND layout, then deep-copies from
     the source view.
-
-    Using Kokkos::create_mirror_view_and_copy is not sufficient here because
-    it preserves the source layout.  When a host execution space (Serial,
-    OpenMP) receives a GPU-allocated view (CudaUVMSpace / LayoutLeft), the
-    mirror would be LayoutLeft/HostSpace but the functor template expects
-    LayoutRight/HostSpace (ExecSpace::array_layout for Serial = LayoutRight).
-    Kokkos::deep_copy handles both the memory-space transfer and the
-    layout conversion in one call.
     """
-    # Build the destination view type with the execution space's native
-    # memory space and array layout.
+    # build destination view type with specified memory and layout
     exec_space: str = Keywords.DefaultExecSpace.value
     dst_type: str = cpp_view_type(
         view_type,
@@ -173,10 +163,7 @@ def _generate_mirror_with_exec_layout(
         real=real,
     )
 
-    # Determine rank to emit the right number of extent() calls.
-    typename: str = view_type.typename
-    match = re.search(r"(?:View|ScratchView)(\d+)D", typename)
-    rank: int = int(match.group(1)) if match else 1
+    rank: int = visitors_util.get_view_rank_from_typename(view_type.typename)
     extents: str = ",".join(f"{src}.extent({i})" for i in range(rank))
 
     code: str = (
@@ -185,7 +172,6 @@ def _generate_mirror_with_exec_layout(
         f"Kokkos::deep_copy({dst}, {src});"
     )
     return code
-
 
 def generate_functor_instance(
     functor: str,
@@ -277,7 +263,7 @@ def generate_copy_back_from_dict(
 
         # Need to resize views for binsort. Unmanaged views cannot be resized.
         if cppast.DeclRefExpr("Unmanaged") not in view_type.template_params:
-            rank = int(re.search(r"\d+", view_type.typename).group())
+            rank = visitors_util.get_view_rank_from_typename(view_type.typename)
             resize_args: List[str] = [v]
 
             for i in range(rank):

--- a/pykokkos/core/translators/bindings.py
+++ b/pykokkos/core/translators/bindings.py
@@ -142,7 +142,6 @@ def get_device_views(members: PyKokkosMembers) -> Dict[str, str]:
     }
 
 
-
 def _generate_mirror_with_exec_layout(
     src: str,
     dst: str,
@@ -167,11 +166,12 @@ def _generate_mirror_with_exec_layout(
     extents: str = ",".join(f"{src}.extent({i})" for i in range(rank))
 
     code: str = (
-        f'{dst_type} {dst}('
+        f"{dst_type} {dst}("
         f'Kokkos::view_alloc("{dst}", Kokkos::WithoutInitializing), {extents});'
         f"Kokkos::deep_copy({dst}, {src});"
     )
     return code
+
 
 def generate_functor_instance(
     functor: str,
@@ -215,13 +215,13 @@ def generate_functor_instance(
                 == Keywords.ArgMemSpace.value
             ):
                 mirror_views += _generate_mirror_with_exec_layout(
-                    v, d_v, view_type, exec_space_instance, None
+                    v, d_v, view_type, None
                 )
             else:
                 mirror_views += f"auto {d_v} = {v};"
         else:
             mirror_views += _generate_mirror_with_exec_layout(
-                v, d_v, members.views[cppast.DeclRefExpr(v)], exec_space_instance, None
+                v, d_v, members.views[cppast.DeclRefExpr(v)], None
             )
 
     # Kokkos fails to compile a functor if there are no parameters in its constructor

--- a/pykokkos/core/visitors/constructor_visitor.py
+++ b/pykokkos/core/visitors/constructor_visitor.py
@@ -92,6 +92,15 @@ class ConstructorVisitor(ast.NodeVisitor):
             if not isinstance(node.annotation, ast.Subscript):
                 return ()
 
+            if (
+                node.value is not None
+                and isinstance(node.value, ast.Subscript)
+                and isinstance(node.value.value, ast.Attribute)
+                and isinstance(node.value.value.value, ast.Name)
+                and node.value.value.value.id == "self"
+            ):
+                return (declref, None)
+
             decltype: cppast.ClassType = visitors_util.get_type(
                 node.annotation, self.pk_import
             )

--- a/pykokkos/core/visitors/visitors_util.py
+++ b/pykokkos/core/visitors/visitors_util.py
@@ -278,6 +278,34 @@ def get_type(
     return None
 
 
+def get_view_rank_from_typename(typename: str) -> int:
+    """
+    Extract view rank from a view type name (e.g. 'View2D', 'ScratchView3D').
+
+    :param typename: view type string such as 'View1D', 'ScratchView2D'
+    :returns: rank as int (1-7)
+    :raises ValueError: if typename is not a valid view type name
+    """
+    if typename.startswith("ScratchView"):
+        suffix = typename[len("ScratchView") :]
+    elif typename.startswith("View"):
+        suffix = typename[len("View") :]
+    else:
+        raise ValueError(
+            f"Expected a view type (e.g., 'View1D', 'View2D', 'ScratchView1D'), "
+            f"but got '{typename}'."
+        )
+    if not suffix.endswith("D") or len(suffix) < 2:
+        raise ValueError(
+            f"Could not extract view rank from typename '{typename}'. "
+            f"Expected format: 'View<rank>D' or 'ScratchView<rank>D' (e.g., 'View1D', 'View2D')"
+        )
+    rank = int(suffix[:-1])
+    if not 0 < rank < 8:
+        raise ValueError(f"View rank {rank} is not allowed")
+    return rank
+
+
 def parse_view_template_params(
     view_type: cppast.ClassType,
     rank: Optional[int] = None,
@@ -308,22 +336,7 @@ def parse_view_template_params(
         )
 
     if rank is None:
-        # Match the rank number that comes after "View" or "ScratchView" and before "D"
-        # This prevents matching numbers from dtype names like "float32" or "float64"
-        match = re.search(r"(?:View|ScratchView)(\d+)D", py_type)
-        if match:
-            rank = int(match.group(1))
-        else:
-            # If pattern doesn't match, this is likely not a valid view type name
-            # or the typename format is unexpected - raise an error instead of
-            # using a fallback that could match wrong numbers from dtype names
-            raise ValueError(
-                f"Could not extract view rank from typename '{py_type}'. "
-                f"Expected format: 'View<rank>D' or 'ScratchView<rank>D' (e.g., 'View1D', 'View2D')"
-            )
-
-    if not 0 < rank < 8:
-        raise ValueError(f"View rank {rank} is not allowed")
+        rank = get_view_rank_from_typename(py_type)
 
     params: Dict[str, str] = {}
 


### PR DESCRIPTION
This PR  fixes the binding issue for the device-sided views that are passed into host-sided kernels.

---

TLDR: if the default space is device, but we call the host kernel - there will be an issue with argument memory layout (Left vs Right). This case should be handled by our side

---

When a _host-space kernel_ (e.g., pk.Serial) is run in a _device_ context, the Python side passes views that live in GPU memory (CudaUVMSpace, LayoutLeft), while **the generated C++ binding expects host views** with the host execution space’s layout (HostSpace, LayoutRight for Serial).

Pybind11 can't automatically cast these types, so we should handle that on our side.
This PR introduces function `_generate_mirror_with_exec_layout` which is handling this case

This PR also adds a compilation check. We should always check if the concrete module file exists, not the module directory.