### PR TITLE
Choose memory space from policy execution space

### DIFF
--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -8,7 +8,7 @@ import pykokkos.kokkos_manager as km
 from pykokkos.core.cppast import BuiltinType
 
 from .execution_policy import ExecutionPolicy, RangePolicy
-from .execution_space import ExecutionSpace, is_host_execution_space
+from .execution_space import ExecutionSpace, DeviceExecutionSpace
 from .views import ViewType, array
 
 from .interface_util import generic_error, get_filename, get_lineno
@@ -234,8 +234,20 @@ def convert_arrays(kwargs: Dict[str, Any], workunit: Callable, execution_space) 
             # Convert Python list to numpy array, then to View
             kwargs[k] = array(np.array(v, dtype=dtype), space=memory_space)
         elif isinstance(v, np.ndarray):
+            if execution_space in DeviceExecutionSpace:
+                raise TypeError(
+                    f"Argument '{k}' is a numpy array, which cannot be accessed "
+                    f"from the {execution_space.value} execution space. "
+                    f"Use a pk.View (e.g. pk.View([...], dtype)) or a CuPy array instead."
+                )
             kwargs[k] = array(v, space=memory_space)
         elif cp_available and isinstance(v, cp.ndarray):
+            if execution_space not in DeviceExecutionSpace:
+                raise TypeError(
+                    f"Argument '{k}' is a CuPy array, which cannot be accessed "
+                    f"from the {execution_space.value} (host) execution space. "
+                    f"Convert it to a numpy array or pk.View in host memory first."
+                )
             kwargs[k] = array(v, space=memory_space)
         elif torch_available and torch.is_tensor(v):
             kwargs[k] = array(v, space=memory_space)


### PR DESCRIPTION
Currently, pykokkos chooses a memory space based off the default execution space, which leads to bugs
when there is a mismatch between policy and default execution spaces.

This PR requires a memory space to be explicitly passed into `convert_array`, ensuring that the python array api object is cast to the correct memory space.