### PR TITLE
views: fix finalization for subview

### DIFF
--- a/pykokkos/__init__.py
+++ b/pykokkos/__init__.py
@@ -113,6 +113,8 @@ def cleanup():
                 view.array = None
             if hasattr(view, "data"):
                 view.data = None
+            if hasattr(view, "xp_array"):
+                view.xp_array = None
         except (ReferenceError, AttributeError):
             pass
 

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -628,6 +628,14 @@ class Subview(ViewType):
         self.ndim = self.data.ndim
         self.size = self.data.size
 
+        try:
+            from pykokkos import _view_registry
+
+            _view_registry.add(self)
+        except (ImportError, AttributeError):
+            pass
+
+
     def _create_slice(self, data_slice: Union[slice, Tuple]) -> List[Union[int, slice]]:
         """
         Transforms the slice into a list, removing all None values for start and stop

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -635,7 +635,6 @@ class Subview(ViewType):
         except (ImportError, AttributeError):
             pass
 
-
     def _create_slice(self, data_slice: Union[slice, Tuple]) -> List[Union[int, slice]]:
         """
         Transforms the slice into a list, removing all None values for start and stop

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -628,12 +628,9 @@ class Subview(ViewType):
         self.ndim = self.data.ndim
         self.size = self.data.size
 
-        try:
-            from pykokkos import _view_registry
+        from pykokkos import _view_registry
 
-            _view_registry.add(self)
-        except (ImportError, AttributeError):
-            pass
+        _view_registry.add(self)
 
     def _create_slice(self, data_slice: Union[slice, Tuple]) -> List[Union[int, slice]]:
         """


### PR DESCRIPTION
https://github.com/kokkos/pykokkos/issues/321 added view registry and weakrefs to catch `finalize`-related issues (finalize after program termination), but there was no added same view registry entry for subviews. 

The ExaMiniMD benchmark also requires this fix, since it uses subviews. We also need it in general for view correctness,