### PR TITLE
Fix atomic fetch op pattern matching in workunit visitor

### DIFF
--- a/pykokkos/core/visitors/workunit_visitor.py
+++ b/pykokkos/core/visitors/workunit_visitor.py
@@ -295,7 +295,7 @@ class WorkunitVisitor(PyKokkosVisitor):
             else:
                 return cppast.CallExpr(function, [args[0], f"pk_id_{work_unit}"])
 
-        atomic_fetch_op: re.Pattern = re.compile("atomic_*")
+        atomic_fetch_op: re.Pattern = re.compile("atomic_fetch_*")
         is_atomic_fetch_op: bool = atomic_fetch_op.match(name)
         is_atomic_increment: bool = name == "atomic_increment"
         is_atomic_compare_exchange: bool = name == "atomic_compare_exchange"


### PR DESCRIPTION
the regex shall be atomic_fetch_* rather than atomic_*,
otherwise, the logic will make atomic_fetch_op to be true when using atomic_compare_exchange, then the if statement : "if not is_atomic_increment and is_atomic_fetch_op and len(args) != 3:" will evaluated to true, which causes the problem