### PR TITLE
Add scratch memory example to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ efficiently on different hardware (CPUs, NVIDIA GPUs, and AMD GPUs)
 with no changes required.
 
 For more information about PyKokkos, see the PyKokkos GitHub pages:
-https://kokkos.github.io/pykokkos/index.html
+https://kokkos.org/pykokkos/
 
 ## Installation
 
@@ -50,7 +50,15 @@ pip install -e .
 ```
 
 For more detailed installation instructions, please visit:
-https://kokkos.github.io/pykokkos/installation.html
+https://kokkos.org/pykokkos/installation.html
+
+## Documentation
+The documentation is available online at https://kokkos.org/pykokkos.
+It can be built locally with the sphinx package by updating the `pyk` conda environment with
+`conda install -c conda-forge sphinx sphinx_rtd_theme`
+and running `cd docs; make html`.
+The resulting html files reside in `_build/html` and
+can be viewed in a browser (e.g., in a bash terminal run `open _build/html/index.html`).
 
 ## Citation
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -29,6 +29,9 @@ that demonstrate various features.
    * - subview
      - `PyKokkos <https://github.com/kokkos/pykokkos/blob/main/examples/kokkos-tutorials/standalone/subview.py>`__
      - `Kokkos <https://github.com/kokkos/kokkos-tutorials/blob/main/Exercises/subview/Solution/exercise_subview_solution.cpp>`__
+   * - scratch memory
+     - `PyKokkos <https://github.com/kokkos/pykokkos/blob/main/examples/kokkos/multi_scratch_team.py>`__
+     - `Kokkos <https://github.com/kokkos/kokkos-tutorials/blob/main/Exercises/team_scratch_memory/Solution/team_scratch_memory_solution.cpp>`__
    * - mdrange
      - `PyKokkos <https://github.com/kokkos/pykokkos/blob/main/examples/kokkos-tutorials/workload/mdrange.py>`__
      - `Kokkos <https://github.com/kokkos/kokkos-tutorials/blob/main/Exercises/mdrange/Solution/exercise_mdrange_solution.cpp>`__

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -87,17 +87,29 @@ install ``base`` with required CMake flags (example performs an install with  Op
 
 
 **CMake Flags**
-===================== ==================
-PyKokkos Flags        Description
-===================== =================
-ENABLE_VIEW_RANKS     Set this value to the max number of ranks needed for Kokkos::View<...>. E.g. value of 4 means Kokkos::View<int*****, Kokkos::HostSpace> cannot be returned to python
-ENABLE_LAYOUTS        Build support for layouts (long NVCC compile times) 
-ENABLE_MEMORY_TRAITS  Build support for memory traits (long NVCC compile times) 
-ENABLE_THREADS        Build Kokkos submodule with Pthread support 
-ENABLE_OPENMP         Build Kokkos submodule with OpenMP support
-ENABLE_CUDA           Build Kokkos submodule with CUDA support
-ENABLE_HIP            Build Kokkos submodule with HIP support
-ARCH                  `Kokkos GPU architecture <https://kokkos.org/kokkos-core-wiki/API/core/Macros.html#architectures>`_, required for HIP builds
+
+.. list-table:: CMake Flags
+   :header-rows: 1
+
+   * - PyKokkos Flags
+     - Description
+   * - ENABLE_VIEW_RANKS
+     - Set this value to the max number of ranks needed for Kokkos::View<...>.
+       E.g. value of 4 means Kokkos::View<int*****, Kokkos::HostSpace> cannot be returned to python
+   * - ENABLE_LAYOUTS
+     - Build support for layouts (long NVCC compile times)
+   * - ENABLE_MEMORY_TRAITS
+     - Build support for memory traits (long NVCC compile times)
+   * - ENABLE_THREADS
+     - Build Kokkos submodule with Pthread support
+   * - ENABLE_OPENMP
+     - Build Kokkos submodule with OpenMP support
+   * - ENABLE_CUDA
+     - Build Kokkos submodule with CUDA support
+   * - ENABLE_HIP
+     - Build Kokkos submodule with HIP support
+   * - ARCH
+     - `Kokkos GPU architecture <https://kokkos.org/kokkos-core-wiki/API/core/Macros.html#architectures>`_
 
 .. note::
         Ensure that amdclang++ is used for building HIP device code 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -85,9 +85,6 @@ install ``base`` with required CMake flags (example performs an install with  Op
       -DENABLE_CUDA=ON \                  # enable cuda execution space
       -DENABLE_OPENMP=ON \                # enable openmp execution space
 
-
-**CMake Flags**
-
 .. list-table:: CMake Flags
    :header-rows: 1
 
@@ -95,7 +92,10 @@ install ``base`` with required CMake flags (example performs an install with  Op
      - Description
    * - ENABLE_VIEW_RANKS
      - Set this value to the max number of ranks needed for Kokkos::View<...>.
-       E.g. value of 4 means Kokkos::View<int*****, Kokkos::HostSpace> cannot be returned to python
+
+       E.g., value of 4 means Kokkos::View<int*****, Kokkos::HostSpace> **cannot** be returned to python
+
+       Higher values lead to longer compile times.
    * - ENABLE_LAYOUTS
      - Build support for layouts (long NVCC compile times)
    * - ENABLE_MEMORY_TRAITS

--- a/examples/kokkos/multi_scratch_team.py
+++ b/examples/kokkos/multi_scratch_team.py
@@ -31,8 +31,8 @@ def scale_kernel(
         team_member.team_scratch(0), N
     )
 
-    # write from global memory to scratch memory, 
-    #   using barriers so each thread in a block 
+    # write from global memory to scratch memory,
+    #   using barriers so each thread in a block
     #   sees the same value.
     scratch_idx[rank] = input_view[offset + rank]
     team_member.team_barrier()
@@ -41,7 +41,7 @@ def scale_kernel(
     scratch_val[rank] = float(scratch_idx[rank]) * scale
     team_member.team_barrier()
 
-    # write from scratch memory to global memory 
+    # write from scratch memory to global memory
     output_view[offset + rank] = scratch_val[rank]
 
 

--- a/examples/kokkos/multi_scratch_team.py
+++ b/examples/kokkos/multi_scratch_team.py
@@ -22,19 +22,26 @@ def scale_kernel(
     offset: int = team_member.league_rank() * team_size
     rank: int = team_member.team_rank()
 
+    # declare scratch view for allocation (int, lambda p: p.n_ints)
     scratch_idx: pk.ScratchView1D[int] = pk.ScratchView1D(
         team_member.team_scratch(0), n_ints
     )
+    # declare scratch view for allocation (float, lambda p: p.N)
     scratch_val: pk.ScratchView1D[float] = pk.ScratchView1D(
         team_member.team_scratch(0), N
     )
 
+    # write from global memory to scratch memory, 
+    #   using barriers so each thread in a block 
+    #   sees the same value.
     scratch_idx[rank] = input_view[offset + rank]
     team_member.team_barrier()
 
+    # ditto
     scratch_val[rank] = float(scratch_idx[rank]) * scale
     team_member.team_barrier()
 
+    # write from scratch memory to global memory 
     output_view[offset + rank] = scratch_val[rank]
 
 


### PR DESCRIPTION
This PR adds scratch memory example to the documentation website and updates the example with instructive comments.

As pork, this PR also adds instructions to the README for building the documentation html locally *and* fixes the CMake flags table in the install documentation.