### PR TITLE
Recompile stale `BASE_DIR`

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -275,8 +275,9 @@ class Compiler:
             main,
             module_setup.metadata,
             space,
-            module_setup.types_signature,
-            module_setup.restrict_signature,
+            module_setup.ast_signature,
+            types_signature=module_setup.types_signature,
+            restrict_signature=module_setup.restrict_signature,
         )
         c_start: float = time.perf_counter()
         cpp_setup.compile(

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -125,11 +125,6 @@ class CppSetup:
         :param name: the name of the directory
         """
 
-        try:
-            shutil.rmtree(name)
-        except OSError:
-            pass
-
         # make the parent directory if necessary
         os.makedirs(name.parent, exist_ok=True)
 

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -117,8 +117,10 @@ class CppSetup:
 
     def initialize_directory(self, name: Path) -> None:
         """
-        Creates an output directory, overwriting an existing directory with the same name.
-        Checks if an older AST directory exists, and if so copies over the relevant information.
+        Checks if an older AST directory exists;
+        if so, copies over the relevant information,
+        otherwise, creates an output directory,
+        overwriting an existing directory with the same name.
 
         :param name: the name of the directory
         """
@@ -129,16 +131,13 @@ class CppSetup:
             pass
 
         # make the parent directory if necessary
-        try:
-            os.makedirs(name.parent, exist_ok=True)
-        except FileExistsError:
-            pass
+        os.makedirs(name.parent, exist_ok=True)
 
         # check if an older AST hash exists
         old_dir = [
             f for f in name.parent.parent.iterdir() if f.is_dir() and f != name.parent
-        ]
-        if len(old_dir) == 1:
+        ]  # this is expected to be 0 or 1 entries
+        if old_dir:
             # if an older AST directory exists, change the name to the new AST directory
             old_dir = old_dir[0]
             old_dir.rename(name.parent)
@@ -153,10 +152,7 @@ class CppSetup:
                 stale_cache_check.unlink()
 
         # make the name directory if necessary
-        try:
-            os.makedirs(name, exist_ok=True)
-        except FileExistsError:
-            pass
+        os.makedirs(name, exist_ok=True)
 
     def write_source(
         self,

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -117,7 +117,8 @@ class CppSetup:
 
     def initialize_directory(self, name: Path) -> None:
         """
-        Creates an output directory, overwriting an existing directory with the same name
+        Creates an output directory, overwriting an existing directory with the same name.
+        Checks if an older AST directory exists, and if so copies over the relevant information.
 
         :param name: the name of the directory
         """
@@ -127,6 +128,31 @@ class CppSetup:
         except OSError:
             pass
 
+        # make the parent directory if necessary
+        try:
+            os.makedirs(name.parent, exist_ok=True)
+        except FileExistsError:
+            pass
+
+        # check if an older AST library exists
+        old_dir = [
+            f for f in name.parent.parent.iterdir() if f.is_dir() and f != name.parent
+        ]
+        if len(old_dir) == 1:
+            # if an older AST directory exists, change the name to the new AST directory
+            old_dir = old_dir[0]
+            old_dir.rename(name.parent)
+            # CMakeCache.txt has hardcoded absolute paths to the old AST directory.
+            # Delete only the cache files so CMake reconfigures with correct paths
+            # while keeping object files in build/ for incremental recompilation.
+            stale_cache = name / "build" / "CMakeCache.txt"
+            if stale_cache.is_file():
+                stale_cache.unlink()
+            stale_cache_check = name / "build" / "CMakeFiles" / "cmake.check_cache"
+            if stale_cache_check.is_file():
+                stale_cache_check.unlink()
+
+        # make the name directory if necessary
         try:
             os.makedirs(name, exist_ok=True)
         except FileExistsError:

--- a/pykokkos/core/cpp_setup.py
+++ b/pykokkos/core/cpp_setup.py
@@ -134,7 +134,7 @@ class CppSetup:
         except FileExistsError:
             pass
 
-        # check if an older AST library exists
+        # check if an older AST hash exists
         old_dir = [
             f for f in name.parent.parent.iterdir() if f.is_dir() and f != name.parent
         ]

--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -169,7 +169,20 @@ class ModuleSetup:
         restrict_signature: Optional[str] = None,
     ) -> Optional[Path]:
         """
-        Get the output directory for an execution space
+        Get the output directory for an execution space.
+
+        The directory structure is hierarchical to allow for efficient caching.
+        The AST signature is given highest priority as it defines the
+        core logic of the kernel; a change in the AST necessitates a new
+        compilation regardless of other parameters. The type signature
+        and restrict signature are used to avoid excessive recompilation;
+        e.g., if a script requires multiple-precision executions of a workunit,
+        both builds are cached using different type signatures, and logic for
+        both builds is ensured to be current by the AST signature.
+
+        Directory structure:
+        [BASE_DIR] / (optional) [TYPE_SIGNATURE] / (optional) [RESTRICT_SIGNATURE] / [AST_SIGNATURE]
+
 
         :param main: the path to the main file in the current PyKokkos application
         :param metadata: the metadata of the entity or fused entities being compiled

--- a/pykokkos/core/module_setup.py
+++ b/pykokkos/core/module_setup.py
@@ -82,6 +82,8 @@ class ModuleSetup:
         self,
         entity: Union[Callable[..., None], type, List[Callable[..., None]]],
         space: ExecutionSpace,
+        ast_signature: str,
+        *,
         types_signature: Optional[str] = None,
         restricted_views: Optional[Set[str]] = None,
     ):
@@ -89,6 +91,7 @@ class ModuleSetup:
         ModuleSetup constructor
 
         :param entity: the functor/workunit/workload or list of workunits for fusion
+        :param ast_signature: hash/string to identify workunit signature against AST
         :param types_signature: hash/string to identify workunit signature against types
         :param restricted_views: a set of view names that do not alias any other views
         """
@@ -103,6 +106,7 @@ class ModuleSetup:
             self.metadata = [get_metadata(entity)]
 
         self.space: ExecutionSpace = space
+        self.ast_signature = ast_signature
         self.types_signature = types_signature
         self.restrict_signature: Optional[str] = None
         if restricted_views is not None:
@@ -126,7 +130,12 @@ class ModuleSetup:
             self.main: Path = self.get_main_path()
 
         self.output_dir: Optional[Path] = self.get_output_dir(
-            self.main, self.metadata, space, types_signature, self.restrict_signature
+            self.main,
+            self.metadata,
+            space,
+            ast_signature,
+            types_signature=types_signature,
+            restrict_signature=self.restrict_signature,
         )
         self.gpu_module_files: List[str] = []
         if km.is_multi_gpu_enabled():
@@ -154,6 +163,8 @@ class ModuleSetup:
         main: Path,
         metadata: List[EntityMetadata],
         space: ExecutionSpace,
+        ast_signature,
+        *,
         types_signature: Optional[str] = None,
         restrict_signature: Optional[str] = None,
     ) -> Optional[Path]:
@@ -163,6 +174,7 @@ class ModuleSetup:
         :param main: the path to the main file in the current PyKokkos application
         :param metadata: the metadata of the entity or fused entities being compiled
         :param space: the execution space to compile for
+        :param ast_signature: hash/string to identify workunit signature against AST
         :param types_signature: optional identifier/hash string for types of parameters
         :param restrict_signature: optional identifier/hash string from the views that do not alias any other views
         :returns: the path to the output directory for a specific execution space
@@ -180,6 +192,8 @@ class ModuleSetup:
             out_dir = out_dir / f"types_{types_signature}"
         if restrict_signature is not None:
             out_dir = out_dir / f"restrict_{restrict_signature}"
+        if ast_signature is not None:
+            out_dir = out_dir / f"AST_{ast_signature}"
 
         out_dir = out_dir / space.value
 
@@ -258,7 +272,8 @@ class ModuleSetup:
                 self.main,
                 self.metadata,
                 self.space,
-                self.types_signature,
-                self.restrict_signature,
+                self.ast_signature,
+                types_signature=self.types_signature,
+                restrict_signature=self.restrict_signature,
             )
         )

--- a/pykokkos/core/parsers/parser.py
+++ b/pykokkos/core/parsers/parser.py
@@ -1,4 +1,5 @@
 import ast
+import hashlib
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -78,6 +79,10 @@ class Parser:
             self.classtypes: Dict[str, PyKokkosEntity] = {}
             self.functors: Dict[str, PyKokkosEntity] = {}
             self.workunits: Dict[str, PyKokkosEntity] = {}
+
+        # get parser signature
+        signature = ast.dump(self.tree)
+        self.signature = hashlib.md5(signature.encode()).hexdigest()
 
     def get_import(self) -> str:
         """

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -174,6 +174,7 @@ class Runtime:
     def precompile_workunit(
         self,
         workunit: Callable[..., None],
+        ast_signature: str,
         space: ExecutionSpace,
         updated_decorator: Optional[UpdatedDecorator],
         updated_types: Optional[UpdatedTypes],
@@ -186,15 +187,21 @@ class Runtime:
         precompile the workunit
 
         :param workunit: the workunit function object
+        :param ast_signature: Hash/identifer string for workunit module against AST
         :param space: the ExecutionSpace for which the bindings are generated
         :param updated_decorator: Object for decorator specifier
         :param updated_types: Object with type inference information
+        :param types_signature: Hash/identifer string for workunit module against data types
         :param restrict_views: a set of view names that do not alias any other views
         :returns: the members the functor is containing
         """
 
         module_setup: ModuleSetup = self.get_module_setup(
-            workunit, space, types_signature, restrict_signature
+            workunit,
+            space,
+            ast_signature,
+            types_signature=types_signature,
+            restrict_signature=restrict_signature,
         )
         members: PyKokkosMembers = self.compiler.compile_object(
             module_setup,
@@ -345,6 +352,7 @@ class Runtime:
         execution_space: ExecutionSpace = policy.space.space
         members: PyKokkosMembers = self.precompile_workunit(
             workunit,
+            parser.signature,
             execution_space,
             updated_decorator,
             updated_types,
@@ -355,7 +363,11 @@ class Runtime:
         )
 
         module_setup: ModuleSetup = self.get_module_setup(
-            workunit, execution_space, types_signature, restrict_signature
+            workunit,
+            execution_space,
+            parser.signature,
+            types_signature=types_signature,
+            restrict_signature=restrict_signature,
         )
         return self.execute(
             workunit,
@@ -812,6 +824,8 @@ class Runtime:
         self,
         entity: Union[object, Callable[..., None]],
         space: ExecutionSpace,
+        ast_signature: str,
+        *,
         types_signature: Optional[str] = None,
         restrict_signature: Optional[str] = None,
     ) -> ModuleSetup:
@@ -820,6 +834,7 @@ class Runtime:
 
         :param entity: the workload or workunit object
         :param space: the execution space
+        :param ast_signature: Hash/identifer string for workunit module against AST
         :param types_signature: Hash/identifer string for workunit module against data types
         :param restrict_signature: Hash/identifer string for views that do not alias any other views
         :returns: the ModuleSetup object
@@ -830,13 +845,23 @@ class Runtime:
         )
 
         module_setup_id = self.get_module_setup_id(
-            entity, space, types_signature, restrict_signature
+            entity,
+            space,
+            ast_signature,
+            types_signature=types_signature,
+            restrict_signature=restrict_signature,
         )
 
         if module_setup_id in self.module_setups:
             return self.module_setups[module_setup_id]
 
-        module_setup = ModuleSetup(entity, space, types_signature, restrict_signature)
+        module_setup = ModuleSetup(
+            entity,
+            space,
+            ast_signature,
+            types_signature=types_signature,
+            restricted_views=restrict_signature,
+        )
         self.module_setups[module_setup_id] = module_setup
 
         return module_setup
@@ -845,6 +870,8 @@ class Runtime:
         self,
         entity: Union[object, Callable[..., None]],
         space: ExecutionSpace,
+        ast_signature: str,
+        *,
         types_signature: Optional[str] = None,
         restrict_signature: Optional[str] = None,
     ) -> Tuple:
@@ -856,6 +883,7 @@ class Runtime:
 
         :param entity: the workload or workunit object
         :param space: the execution space
+        :param ast_signature: Hash/identifer string for workunit module against AST
         :param types_signature: optional identifier/hash string for
             types of parameters against workunit module
         :param restrict_signature: Hash/identifer string for views
@@ -890,6 +918,7 @@ class Runtime:
                 module_setup_id_list.append(types_signature)
             if restrict_signature is not None:
                 module_setup_id_list.append(restrict_signature)
+            module_setup_id_list.append(ast_signature)
 
             module_setup_id = tuple(module_setup_id_list)
 

--- a/pykokkos/core/runtime.py
+++ b/pykokkos/core/runtime.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import sys
 from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, Union, List
 import sysconfig
+import hashlib
 
 import numpy as np
 
@@ -349,10 +350,17 @@ class Runtime:
             }
             restrict_views, restrict_signature = get_restrict_views(view_dict)
 
+        # Set ast signature
+        if isinstance(parser, list):
+            ast_signature = "".join([p.signature for p in parser])
+            ast_signature = hashlib.md5(ast_signature.encode()).hexdigest()
+        else:
+            ast_signature = parser.signature
+
         execution_space: ExecutionSpace = policy.space.space
         members: PyKokkosMembers = self.precompile_workunit(
             workunit,
-            parser.signature,
+            ast_signature,
             execution_space,
             updated_decorator,
             updated_types,
@@ -365,7 +373,7 @@ class Runtime:
         module_setup: ModuleSetup = self.get_module_setup(
             workunit,
             execution_space,
-            parser.signature,
+            ast_signature,
             types_signature=types_signature,
             restrict_signature=restrict_signature,
         )

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -24,7 +24,7 @@ BUGGY_SOURCE = textwrap.dedent("""\
     import pykokkos as pk
  
     @pk.workunit
-    def add1(i, arr):
+    def add1(i: int, arr: pk.View1D[int]):
         arr[i] += 2
 """)
 
@@ -32,7 +32,7 @@ CORRECT_SOURCE = textwrap.dedent("""\
     import pykokkos as pk
  
     @pk.workunit
-    def add1(i, arr):
+    def add1(i: int, arr: pk.View1D[int]):
         arr[i] += 1
 """)
 

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -73,7 +73,7 @@ def test_recompilation(tmp_path):
     arr_buggy = np.zeros(n, dtype=np.int32)
     pk.parallel_for(n, mod_buggy.add1, arr=arr_buggy)
 
-    # assert buggy array is correct
+    # assert add2 array is correct
     try:
         np.testing.assert_equal(arr_buggy, np.zeros(n, dtype=np.int32) + 2)
     except AssertionError as e:

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -20,21 +20,25 @@ from pathlib import Path
 import numpy as np
 import pykokkos as pk
 
-BUGGY_SOURCE = textwrap.dedent("""\
+BUGGY_SOURCE = textwrap.dedent(
+    """\
     import pykokkos as pk
  
     @pk.workunit
     def add1(i: int, arr: pk.View1D[int]):
         arr[i] += 2
-""")
+"""
+)
 
-CORRECT_SOURCE = textwrap.dedent("""\
+CORRECT_SOURCE = textwrap.dedent(
+    """\
     import pykokkos as pk
  
     @pk.workunit
     def add1(i: int, arr: pk.View1D[int]):
         arr[i] += 1
-""")
+"""
+)
 
 MODULE_NAME = "_test_jit_kernel_add1"
 

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -76,6 +76,10 @@ def test_recompilation(tmp_path):
         raise AssertionError("buggy kernel is incorrect") from e
 
     # ---- Stage 2: correct kernel
+
+    # reload pykokkos to clear cache
+    importlib.reload(sys.modules["pykokkos"])
+
     kernel_file.write_text(CORRECT_SOURCE, encoding="utf-8")
     mod_correct = _load_fresh(kernel_file)
 

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import numpy as np
 import pykokkos as pk
 
-BUGGY_SOURCE = textwrap.dedent(
+WORKUNIT_V1 = textwrap.dedent(
     """\
     import pykokkos as pk
  
@@ -30,7 +30,7 @@ BUGGY_SOURCE = textwrap.dedent(
 """
 )
 
-CORRECT_SOURCE = textwrap.dedent(
+WORKUNIT_V2 = textwrap.dedent(
     """\
     import pykokkos as pk
  
@@ -61,21 +61,21 @@ def _load_fresh(path: Path):
 def test_recompilation(tmp_path):
     kernel_file = tmp_path / "_test_jit_recompile.py"
 
-    # ---- Stage 1: buggy kernel
+    # ---- Stage 1: workunit v1 (add 2 to the array)
     # write buggy source
-    kernel_file.write_text(BUGGY_SOURCE, encoding="utf-8")
+    kernel_file.write_text(WORKUNIT_V1, encoding="utf-8")
 
-    # load buggy source
+    # load source for workunit v1
     mod_buggy = _load_fresh(kernel_file)
 
     # run the buggy kernel
     n = 5
-    arr_buggy = np.zeros(n, dtype=np.int32)
-    pk.parallel_for(n, mod_buggy.add1, arr=arr_buggy)
+    arr_v1 = np.zeros(n, dtype=np.int32)
+    pk.parallel_for(n, mod_buggy.add1, arr=arr_v1)
 
-    # assert add2 array is correct
+    # assert workunit v1 array is correct
     try:
-        np.testing.assert_equal(arr_buggy, np.zeros(n, dtype=np.int32) + 2)
+        np.testing.assert_equal(arr_v1, np.zeros(n, dtype=np.int32) + 2)
     except AssertionError as e:
         raise AssertionError("buggy kernel is incorrect") from e
 
@@ -84,15 +84,15 @@ def test_recompilation(tmp_path):
     # reload pykokkos to clear cache
     importlib.reload(sys.modules["pykokkos"])
 
-    kernel_file.write_text(CORRECT_SOURCE, encoding="utf-8")
+    kernel_file.write_text(WORKUNIT_V2, encoding="utf-8")
     mod_correct = _load_fresh(kernel_file)
 
-    arr_correct = np.zeros(n, dtype=np.int32)
-    pk.parallel_for(n, mod_correct.add1, arr=arr_correct)
+    arr_v2 = np.zeros(n, dtype=np.int32)
+    pk.parallel_for(n, mod_correct.add1, arr=arr_v2)
     expected = np.zeros(n, dtype=np.int32) + 1
     try:
-        np.testing.assert_equal(arr_correct, expected)
+        np.testing.assert_equal(arr_v2, expected)
     except AssertionError as e:
         raise AssertionError(
-            f"kernel is incorrect\nactual:  {arr_correct}\ndesired: {expected}"
+            f"kernel is incorrect\nactual:  {arr_v2}\ndesired: {expected}"
         ) from e

--- a/tests/test_recompile.py
+++ b/tests/test_recompile.py
@@ -1,0 +1,90 @@
+"""
+pytest: PyKokkos JIT kernel recompilation test.
+
+Tests that modifying a @pk.workunit source file triggers recompilation
+and that both versions of the kernel produce correct results.
+
+Workflow:
+  1. Write the "buggy" kernel (arr[i] += 2) to a temp module file.
+  2. Import it and run it — verify each element increased by 2.
+  3. Overwrite the module file with the "fixed" kernel (arr[i] += 1).
+  4. Invalidate Python's module cache so the new source is picked up.
+  5. Re-import and run — verify each element increased by 1.
+"""
+
+import sys
+import textwrap
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pykokkos as pk
+
+BUGGY_SOURCE = textwrap.dedent("""\
+    import pykokkos as pk
+ 
+    @pk.workunit
+    def add1(i, arr):
+        arr[i] += 2
+""")
+
+CORRECT_SOURCE = textwrap.dedent("""\
+    import pykokkos as pk
+ 
+    @pk.workunit
+    def add1(i, arr):
+        arr[i] += 1
+""")
+
+MODULE_NAME = "_test_jit_kernel_add1"
+
+
+def _load_fresh(path: Path):
+    """Force a fresh import of the module at *path*, bypassing sys.modules."""
+    # Remove any previously cached version.
+    sys.modules.pop(MODULE_NAME, None)
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------- Test JIT Recompilation ----------
+
+
+def test_recompilation(tmp_path):
+    kernel_file = tmp_path / "_test_jit_recompile.py"
+
+    # ---- Stage 1: buggy kernel
+    # write buggy source
+    kernel_file.write_text(BUGGY_SOURCE, encoding="utf-8")
+
+    # load buggy source
+    mod_buggy = _load_fresh(kernel_file)
+
+    # run the buggy kernel
+    n = 5
+    arr_buggy = np.zeros(n, dtype=np.int32)
+    pk.parallel_for(n, mod_buggy.add1, arr=arr_buggy)
+
+    # assert buggy array is correct
+    try:
+        np.testing.assert_equal(arr_buggy, np.zeros(n, dtype=np.int32) + 2)
+    except AssertionError as e:
+        raise AssertionError("buggy kernel is incorrect") from e
+
+    # ---- Stage 2: correct kernel
+    kernel_file.write_text(CORRECT_SOURCE, encoding="utf-8")
+    mod_correct = _load_fresh(kernel_file)
+
+    arr_correct = np.zeros(n, dtype=np.int32)
+    pk.parallel_for(n, mod_correct.add1, arr=arr_correct)
+    expected = np.zeros(n, dtype=np.int32) + 1
+    try:
+        np.testing.assert_equal(arr_correct, expected)
+    except AssertionError as e:
+        raise AssertionError(
+            f"kernel is incorrect\nactual:  {arr_correct}\ndesired: {expected}"
+        ) from e


### PR DESCRIPTION
Closes #100, #234.

## Features

**1. AST-hashed compilation directories**
`pk_cpp` output directories now include an `AST_<hash>` subdirectory that encodes a structural hash of the compiled workunit. On each invocation, PyKokkos computes the current AST hash and compares it against the on-disk directory name; if the AST hashes differ, recompilation is triggered. This replaces the previous approach which **did not** check if the compiled AST matched the current AST.

**2. Incremental recompilation on AST change**
When a workunit's AST hash changes, `initialize_directory` renames the old `AST_<hash>` directory to the new hash rather than discarding it. Only `CMakeCache.txt` and `cmake.check_cache` are deleted (as they contain hardcoded absolute paths that CMake rejects after a rename), while all object files and link artifacts in `build/` are preserved. This allows CMake to perform an incremental rebuild rather than compiling from scratch.

**3. Recompilation unit test**
Adds `test_recompilation` which verifies end-to-end that modifying a `@pk.workunit` body triggers a correct recompile. The test writes a buggy kernel (`arr[i] += 2`), runs it and asserts the output, then overwrites it with the fixed kernel (`arr[i] += 1`) and asserts the recompiled output, confirming that stale builds are invalidated and that the new kernel produces correct results.