### PR TITLE
set UVM off by default if CUDA is enabled (deprecated by Kokkos)

### DIFF
--- a/base/cmake/Modules/KokkosPythonKokkos.cmake
+++ b/base/cmake/Modules/KokkosPythonKokkos.cmake
@@ -166,7 +166,7 @@ IF(_INTERNAL_KOKKOS)
     # define the kokkos option as default and/or get it to display
     IF(ENABLE_CUDA)
         ADD_OPTION(Kokkos_ENABLE_CUDA "Build Kokkos submodule with CUDA support" ON)
-        ADD_OPTION(Kokkos_ENABLE_CUDA_UVM "Build Kokkos submodule with CUDA UVM support" ON)
+        ADD_OPTION(Kokkos_ENABLE_CUDA_UVM "Build Kokkos submodule with CUDA UVM support" OFF)
         ADD_OPTION(Kokkos_ENABLE_CUDA_LAMBDA "Build Kokkos submodule with CUDA lambda support" ON)
         if (ARCH)
             ADD_OPTION(Kokkos_ARCH_${ARCH} "Target NVIDIA GPU architecture: ${ARCH}" ON)

--- a/base/cmake/Modules/KokkosPythonKokkos.cmake
+++ b/base/cmake/Modules/KokkosPythonKokkos.cmake
@@ -166,7 +166,6 @@ IF(_INTERNAL_KOKKOS)
     # define the kokkos option as default and/or get it to display
     IF(ENABLE_CUDA)
         ADD_OPTION(Kokkos_ENABLE_CUDA "Build Kokkos submodule with CUDA support" ON)
-        ADD_OPTION(Kokkos_ENABLE_CUDA_UVM "Build Kokkos submodule with CUDA UVM support" OFF)
         ADD_OPTION(Kokkos_ENABLE_CUDA_LAMBDA "Build Kokkos submodule with CUDA lambda support" ON)
         if (ARCH)
             ADD_OPTION(Kokkos_ARCH_${ARCH} "Target NVIDIA GPU architecture: ${ARCH}" ON)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -110,6 +110,8 @@ install ``base`` with required CMake flags (example performs an install with  Op
      - Build Kokkos submodule with HIP support
    * - ARCH
      - `Kokkos GPU architecture <https://kokkos.org/kokkos-core-wiki/API/core/Macros.html#architectures>`_
+   * - Kokkos_ENABLE_CUDA_UVM
+     - Build Kokkos submodule with CUDA UVM support. Off by default.
 
 .. note::
         Ensure that amdclang++ is used for building HIP device code 


### PR DESCRIPTION
This PR removes the deprecated CUDA `UVM` memory space option, which causes slowdowns due to page-fetch faults during kernel execution.

<!-- Since the changes are related to CUDA space, we ran tests locally and verified their correctness. -->