### PR TITLE
Assert that numpy-like arrays are contiguous

### DIFF
--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -964,6 +964,9 @@ def array(
     :returns: a PyKokkos View wrapping the array
     """
 
+    if not array.flags["F_CONTIGUOUS"] and not array.flags["C_CONTIGUOUS"]:
+        raise ValueError(f"numpy array is not contiguous")
+
     # if numpy array, use from_numpy()
     if isinstance(array, np.ndarray) or np.isscalar(array):
         return from_numpy(array, space, layout)

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -964,6 +964,15 @@ def array(
     :returns: a PyKokkos View wrapping the array
     """
 
+    # if an array is not a recognized type, try coasting it to a numpy array
+    if (
+        not isinstance(array, np.ndarray)
+        and not np.isscalar(array)
+        and not is_array(array)
+    ):
+        array = np.asarray(array)
+
+    # check that the array is contiguous
     if not array.flags["F_CONTIGUOUS"] and not array.flags["C_CONTIGUOUS"]:
         raise ValueError(f"numpy array is not contiguous")
 
@@ -972,10 +981,10 @@ def array(
         return from_numpy(array, space, layout)
     # test if the input array can duck-type to a numpy-like array
     # and run from_array to preprocess the array to numpy
-    if is_array(array):
+    elif is_array(array):
         return from_array(array)
-    # try converting the input data to numpy and using that route to convert
-    return from_numpy(np.asarray(array), space, layout)
+    else:
+        raise TypeError(f"array of type {type(array)} not supported")
 
 
 # asarray is required for comformance with the array API:

--- a/pykokkos/interface/views.py
+++ b/pykokkos/interface/views.py
@@ -785,8 +785,10 @@ def from_numpy(
     if layout is None and array.ndim > 1:
         if array.flags["F_CONTIGUOUS"]:
             layout = Layout.LayoutLeft
-        else:
+        elif array.flags["C_CONTIGUOUS"]:
             layout = Layout.LayoutRight
+        else:
+            raise ValueError(f"numpy array is not contiguous")
 
     if space is None:
         space = MemorySpace.MemorySpaceDefault
@@ -914,8 +916,10 @@ def from_array(array) -> ViewType:
     layout: Layout
     if array.flags["F_CONTIGUOUS"]:
         layout = Layout.LayoutLeft
-    else:
+    elif array.flags["C_CONTIGUOUS"]:
         layout = Layout.LayoutRight
+    else:
+        raise ValueError("array is not contiguous")
 
     memory_space: MemorySpace
     if km.get_gpu_framework() is pk.Cuda:

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -695,11 +695,11 @@ class TestTypeInference(unittest.TestCase):
         expected = sum(sum(sum(row) for row in plane) for plane in python_3d)
         self.assertEqual(result[0], expected)
 
-    def test_numpy_non_contiguous(self):
-        contigous = np.arange(10)
+    def test_numpy_noncontiguous(self):
+        contiguous = np.arange(10)
         noncontiguous = contiguous[::2]
         with pytest.raises(ValueError):
-            pk.parallel_for(len(noncontigous), init_view, view=non_contiguous, init=0)
+            pk.parallel_for(len(noncontiguous), init_view, view=noncontiguous, init=0)
 
 
 if __name__ == "__main__":

--- a/tests/test_typeinference.py
+++ b/tests/test_typeinference.py
@@ -695,6 +695,12 @@ class TestTypeInference(unittest.TestCase):
         expected = sum(sum(sum(row) for row in plane) for plane in python_3d)
         self.assertEqual(result[0], expected)
 
+    def test_numpy_non_contiguous(self):
+        contigous = np.arange(10)
+        noncontiguous = contiguous[::2]
+        with pytest.raises(ValueError):
+            pk.parallel_for(len(noncontigous), init_view, view=non_contiguous, init=0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This stems form an issue where a PyKokkos kernel was passed a non-contiguous numpy array, leading to a segfault. This should be caught on the PyKokkos side.