### PR TITLE
feat: add helper function to check type alignment

### DIFF
--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -1,3 +1,4 @@
+import ctypes
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -49,6 +50,16 @@ BUILTIN_TO_NUMPY: Dict[str, np.dtype] = {
 }
 
 
+def c_float_dtype_name() -> str:
+    c_float_size = ctypes.sizeof(ctypes.c_float)
+    if c_float_size == np.dtype(np.float32).itemsize:
+        return "float32"
+    if c_float_size == np.dtype(np.float64).itemsize:
+        return "float64"
+
+    raise TypeError(f"Unsupported C float size: {c_float_size} bytes")
+
+
 def normalize_dtype_name(dtype) -> Optional[str]:
     if dtype is int:
         return "int32"
@@ -66,7 +77,7 @@ def normalize_dtype_name(dtype) -> Optional[str]:
 
     aliases = {
         "bool": "uint8",
-        "float": "float32",
+        "float": c_float_dtype_name(),
         "double": "float64",
     }
     return aliases.get(dtype_name, dtype_name)
@@ -97,13 +108,7 @@ def check_view_dtype_matches_annotation(
     if expected == actual:
         return
 
-    raise TypeError(
-        f"Argument '{arg_name}' expects a View with dtype {expected}, "
-        f"but received dtype {actual}. NumPy and CuPy dtype=int default to "
-        f"int64 on many platforms; use an explicit dtype such as np.int32 "
-        f"or cp.int32, or update the workunit annotation to match the "
-        f"array dtype."
-    )
+    raise TypeError(f"Argument '{arg_name}' expects a View with dtype {expected}.")
 
 
 def parse_list_annotation(annotation) -> Tuple[int, np.dtype]:

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -1,5 +1,15 @@
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    get_args,
+    get_origin,
+)
 
 import numpy as np
 
@@ -7,6 +17,7 @@ from pykokkos.runtime import runtime_singleton
 import pykokkos.kokkos_manager as km
 from pykokkos.core.cppast import BuiltinType
 
+from .data_types import DataType, DataTypeClass
 from .execution_policy import ExecutionPolicy, RangePolicy
 from .execution_space import ExecutionSpace, DeviceExecutionSpace
 from .reducers import Reducer
@@ -36,6 +47,63 @@ BUILTIN_TO_NUMPY: Dict[str, np.dtype] = {
     BuiltinType.DOUBLE.value: np.float64,
     BuiltinType.BOOL.value: np.bool_,
 }
+
+
+def normalize_dtype_name(dtype) -> Optional[str]:
+    if dtype is int:
+        return "int32"
+    if dtype is float:
+        return "float64"
+    if dtype is bool:
+        return "uint8"
+
+    if isinstance(dtype, DataType):
+        dtype_name = dtype.name
+    elif isinstance(dtype, type) and issubclass(dtype, DataTypeClass):
+        dtype_name = dtype.__name__
+    else:
+        return None
+
+    aliases = {
+        "bool": "uint8",
+        "float": "float32",
+        "double": "float64",
+    }
+    return aliases.get(dtype_name, dtype_name)
+
+
+def get_view_annotation_dtype(annotation) -> Optional[str]:
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if origin is None or len(args) == 0:
+        return None
+
+    origin_name = getattr(origin, "__name__", "")
+    if not origin_name.startswith("View"):
+        return None
+
+    return normalize_dtype_name(args[0])
+
+
+def check_view_dtype_matches_annotation(
+    arg_name: str, annotation, view: ViewType
+) -> None:
+    expected = get_view_annotation_dtype(annotation)
+    if expected is None:
+        return
+
+    actual = normalize_dtype_name(view.dtype)
+    if expected == actual:
+        return
+
+    raise TypeError(
+        f"Argument '{arg_name}' expects a View with dtype {expected}, "
+        f"but received dtype {actual}. NumPy and CuPy dtype=int default to "
+        f"int64 on many platforms; use an explicit dtype such as np.int32 "
+        f"or cp.int32, or update the workunit annotation to match the "
+        f"array dtype."
+    )
 
 
 def parse_list_annotation(annotation) -> Tuple[int, np.dtype]:
@@ -284,6 +352,10 @@ def convert_arrays(kwargs: Dict[str, Any], workunit: Callable, execution_space) 
             lineno = get_lineno(caller_frame)
             msg = f"Type {type(v)} is not supported. Only numpy arrays, cupy arrays, and torch tensors are supported."
             generic_error(filename, lineno, msg, "Conversion failed")
+
+    for k, v in kwargs.items():
+        if isinstance(v, ViewType) and k in type_hints:
+            check_view_dtype_matches_annotation(k, type_hints[k], v)
 
 
 def parallel_for(*args, **kwargs) -> None:

--- a/pykokkos/interface/parallel_dispatch.py
+++ b/pykokkos/interface/parallel_dispatch.py
@@ -108,7 +108,10 @@ def check_view_dtype_matches_annotation(
     if expected == actual:
         return
 
-    raise TypeError(f"Argument '{arg_name}' expects a View with dtype {expected}.")
+    raise TypeError(
+        f"Argument '{arg_name}' expects a View with dtype {expected}, "
+        f"but received dtype {actual}."
+    )
 
 
 def parse_list_annotation(annotation) -> Tuple[int, np.dtype]:

--- a/tests/test_view_dtype_mismatch.py
+++ b/tests/test_view_dtype_mismatch.py
@@ -56,7 +56,7 @@ def test_numpy_array_int64_rejected_for_int32_view():
 def test_numpy_int64_rejected_for_bare_int_view():
     arr = pk.array(np.ones(8, dtype=int))
 
-    with pytest.raises(TypeError, match="dtype=int default to int64"):
+    with pytest.raises(TypeError, match="expects a View with dtype int32"):
         pk.parallel_for(openmp_policy(8), scale_int, arr=arr)
 
 

--- a/tests/test_view_dtype_mismatch.py
+++ b/tests/test_view_dtype_mismatch.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+
+import pykokkos as pk
+from pykokkos.interface.parallel_dispatch import convert_arrays
+
+
+@pk.workunit
+def scale_int32(i: int, arr: pk.View1D[pk.int32]) -> None:
+    arr[i] = arr[i] * 2
+
+
+@pk.workunit
+def scale_int(i: int, arr: pk.View1D[int]) -> None:
+    arr[i] = arr[i] * 2
+
+
+@pk.workunit
+def scale_float32(i: int, arr: pk.View1D[pk.float]) -> None:
+    arr[i] = arr[i] * 2
+
+
+@pk.workunit
+def scale_float(i: int, arr: pk.View1D[float]) -> None:
+    arr[i] = arr[i] * 2
+
+
+@pk.workunit
+def scale_unannotated(i: int, arr) -> None:
+    arr[i] = arr[i] * 2
+
+
+def openmp_policy(size: int):
+    return pk.RangePolicy(pk.ExecutionSpace.OpenMP, 0, size)
+
+
+def convert_for_openmp(workunit, **kwargs):
+    convert_arrays(kwargs, workunit, pk.ExecutionSpace.OpenMP)
+    return kwargs
+
+
+def test_numpy_int64_rejected_for_int32_view():
+    arr = pk.array(np.ones(8, dtype=int))
+
+    with pytest.raises(TypeError, match="expects a View with dtype int32"):
+        pk.parallel_for(openmp_policy(8), scale_int32, arr=arr)
+
+
+def test_numpy_array_int64_rejected_for_int32_view():
+    arr = np.ones(8, dtype=int)
+
+    with pytest.raises(TypeError, match="expects a View with dtype int32"):
+        pk.parallel_for(openmp_policy(8), scale_int32, arr=arr)
+
+
+def test_numpy_int64_rejected_for_bare_int_view():
+    arr = pk.array(np.ones(8, dtype=int))
+
+    with pytest.raises(TypeError, match="dtype=int default to int64"):
+        pk.parallel_for(openmp_policy(8), scale_int, arr=arr)
+
+
+def test_numpy_int32_accepted_for_int32_view():
+    kwargs = convert_for_openmp(scale_int32, arr=np.ones(8, dtype=np.int32))
+
+    assert kwargs["arr"].dtype is pk.int32
+
+
+def test_numpy_float64_rejected_for_float32_view():
+    arr = pk.array(np.ones(8, dtype=np.float64))
+
+    with pytest.raises(TypeError, match="expects a View with dtype float32"):
+        pk.parallel_for(openmp_policy(8), scale_float32, arr=arr)
+
+
+def test_numpy_float32_rejected_for_bare_float_view():
+    arr = pk.array(np.ones(8, dtype=np.float32))
+
+    with pytest.raises(TypeError, match="expects a View with dtype float64"):
+        pk.parallel_for(openmp_policy(8), scale_float, arr=arr)
+
+
+def test_unannotated_numpy_int64_view_is_inferred_as_int64():
+    kwargs = convert_for_openmp(scale_unannotated, arr=np.ones(8, dtype=int))
+
+    assert kwargs["arr"].dtype is pk.int64


### PR DESCRIPTION
## View Dtype Annotation Validation

`pykokkos/interface/parallel_dispatch.py` now validates explicit `View` dtype annotations against the actual dtype of the provided `View`.

### Changes

A new helper has been added to:

* Normalize PyKokkos and Python dtype aliases into comparable canonical names
* Extract the expected dtype from annotations such as `pk.View1D[pk.int32]`
* Compare the expected dtype against the actual `View.dtype`
* Raise a clear and informative `TypeError` when the dtypes do not match

### Examples

```python
@pk.workunit
def work(v: pk.View1D[pk.int32]):
    ...
```

Passing a `View` with dtype `int64` now raises a `TypeError` indicating the mismatch between the annotated and actual dtypes.

### Tests

Added `tests/test_view_dtype_mismatch.py` with coverage for:

#### Invalid dtype combinations

* Rejecting `int64` arrays passed to `pk.View1D[pk.int32]`
* Rejecting NumPy `dtype=int` arrays passed to `pk.View1D[int]`
* Rejecting `float64` arrays passed to `pk.View1D[pk.float]`
* Rejecting `float32` arrays passed to `pk.View1D[float]`

#### Valid dtype combinations

* Accepting `int32` arrays passed to `pk.View1D[pk.int32]`

#### Existing behavior preserved

* Preserving type inference for unannotated `int64` views
