### PR TITLE
core: update mypy and resolve issues

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==1.0.1 cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy==1.20 cmake pytest pybind11 scikit-build patchelf
       - name: Install pykokkos-base
         run: |
           python install_base.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=1

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==1.0.1 cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy==1.20 cmake pytest pybind11 scikit-build patchelf
       - name: Install pykokkos-base
         run: |
           python install_base.py install -- -DENABLE_LAYOUTS=ON -DENABLE_MEMORY_TRAITS=OFF -DENABLE_VIEW_RANKS=1

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==1.0.1 cmake pytest pybind11 scikit-build patchelf
+          python -m pip install --upgrade numpy mypy==1.20 cmake pytest pybind11 scikit-build patchelf
       - name: Install pykokkos-base
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade numpy mypy==0.981 cmake pytest pybind11 scikit-build patchelf ninja
+          python -m pip install --upgrade numpy mypy==1.20 cmake pytest pybind11 scikit-build patchelf ninja
       - name: Build Kokkos develop branch
         run: |
           cd /tmp

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,6 @@ warn_redundant_casts = True
 warn_unused_ignores = True
 show_error_codes = True
 allow_empty_bodies = True
-plugins = numpy.typing.mypy_plugin
 
 # third party dependencies
 

--- a/pykokkos/core/translators/symbols_pass.py
+++ b/pykokkos/core/translators/symbols_pass.py
@@ -187,8 +187,9 @@ class SymbolsPass:
             if symbol is None:
                 sys.exit("Internal Error")
 
+            lineno = getattr(node, "lineno", "unknown")
             message: str = (
-                f'File "{self.path}", line {node.lineno}:\n {error.value} symbol {symbol} used'
+                f'File "{self.path}", line {lineno}:\n {error.value} symbol {symbol} used'
             )
             messages.append(message)
 


### PR DESCRIPTION
The CI was using an old version of `mypy` that was not compatible with all supported numpy versions. I bumped the mypy version in the CI to `1.20`, the latest release of `mypy v1`.

Two other mypy issues came up with the updated release:

1. Not all `ATS` objects have a `lineno` attributed, so I added a failsafe that returns `'unknown'` when there is no `lineno` attribute.
2. `numpy.typing.mypy_plugin` is now depreciated, so I removed it from `mypy.init`.