### PR TITLE
example: remove deprecated UVM enabling in ExaMiniMD

### DIFF
--- a/examples/ExaMiniMD/workload/src/examinimd.py
+++ b/examples/ExaMiniMD/workload/src/examinimd.py
@@ -26,8 +26,6 @@ class ExaMiniMD:
         space: Optional[str] = os.environ.get("PK_EXA_SPACE")
         if space is not None:
             pk.set_default_space(pk.ExecutionSpace(space))
-            if space in {"Cuda", "HIP"}:
-                pk.enable_uvm()
 
         self.system = System()
         self.system.init()


### PR DESCRIPTION
## Description

#418 removed UVM spaces from core, but we still have some `enable_uvm()` in the examples. This PR removes it

Closes: N/A

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Refactor / code cleanup
- [ ] Other: <!-- describe -->

## Checklist

- [X] Code is formatted with `black==25.12.0` (CI will enforce this)
- [ ] Tests pass locally with `python3 runtests.py`
- [ ] New or updated unit tests added in the `test` directory where applicable
- [ ] Examples added in `examples/pykokkos` for large feature changes
- [X] PR title follows the `module: feature` naming convention


## Additional Notes

Related to #418. Part of #432