### PR TITLE
Fix nested workunits

### DIFF
--- a/pykokkos/core/compiler.py
+++ b/pykokkos/core/compiler.py
@@ -161,7 +161,9 @@ class Compiler:
             # Avoid fusing the ASTs before checking if it was already compiled
             entity, classtypes = self.fuse_objects(metadata, fuse_ASTs=False, **kwargs)
 
-        hash: str = self.members_hash(entity.path, entity.name, types_signature)
+        hash: str = self.members_hash(
+            entity.path, entity.name, module_setup.ast_signature, types_signature
+        )
 
         types_inferred: bool = updated_types is not None
         decorator_inferred: bool = updated_decorator is not None
@@ -393,21 +395,26 @@ class Compiler:
         return defaults
 
     def members_hash(
-        self, path: List[str], name: str, types_signature: Optional[str]
+        self,
+        path: List[str],
+        name: str,
+        ast_signature: str,
+        types_signature: Optional[str],
     ) -> str:
         """
         Map from entity path and name to a string to index members
 
         :param path: the path to the file containing the entity
         :param name: the name of the entity
+        :param ast_signature: signature of the parsed module AST
         :param types_signature: string signature of inferred parameter types
         :returns: the hash of the entity
         """
 
         return (
-            f"{path}_{name}"
+            f"{path}_{name}_{ast_signature}"
             if types_signature is None
-            else f"{path}_{name}_{types_signature}"
+            else f"{path}_{name}_{ast_signature}_{types_signature}"
         )
 
     def extract_members(

--- a/pykokkos/core/translators/members.py
+++ b/pykokkos/core/translators/members.py
@@ -319,6 +319,8 @@ class PyKokkosMembers:
                     continue
 
                 name = call.func.id
+                if visitors_util.is_math_function(name):
+                    continue
                 dependency = module_functions.get(name)
                 reference = cppast.DeclRefExpr(name)
                 if dependency is None or reference in self.pk_workunits:

--- a/pykokkos/core/translators/members.py
+++ b/pykokkos/core/translators/members.py
@@ -82,7 +82,7 @@ class PyKokkosMembers:
                     param_begin = i + 1
                     # handle last_pass param for parallel_scan
                     if (
-                        i + 1 <= len(args)
+                        i + 1 < len(args)
                         and isinstance(args[i + 1].annotation, ast.Name)
                         and args[i + 1].annotation.id == "bool"
                     ):

--- a/pykokkos/core/translators/members.py
+++ b/pykokkos/core/translators/members.py
@@ -117,6 +117,7 @@ class PyKokkosMembers:
             self.pk_functions = self.get_decorated_functions(
                 entity.full_AST, Decorator.KokkosFunction
             )
+            self.add_called_functions(AST, entity.full_AST)
 
         self.classtype_methods = self.get_classtype_methods(classtypes)
 
@@ -296,6 +297,35 @@ class PyKokkosMembers:
             visitor.visit(method)
 
         return functions
+
+    def add_called_functions(self, root: ast.FunctionDef, module: ast.Module) -> None:
+        """Add undecorated module-level functions reachable from a workunit."""
+
+        module_functions = {
+            node.name: node for node in module.body if isinstance(node, ast.FunctionDef)
+        }
+        pending = [root, *self.pk_functions.values()]
+        visited: Set[str] = set()
+
+        while pending:
+            function = pending.pop()
+            if function.name in visited:
+                continue
+            visited.add(function.name)
+
+            calls = (node for node in ast.walk(function) if isinstance(node, ast.Call))
+            for call in calls:
+                if not isinstance(call.func, ast.Name):
+                    continue
+
+                name = call.func.id
+                dependency = module_functions.get(name)
+                reference = cppast.DeclRefExpr(name)
+                if dependency is None or reference in self.pk_workunits:
+                    continue
+                if reference not in self.pk_functions:
+                    self.pk_functions[reference] = dependency
+                pending.append(dependency)
 
     def get_classtype_methods(
         self, classtypes: List[PyKokkosEntity]

--- a/tests/test_implicit_functions.py
+++ b/tests/test_implicit_functions.py
@@ -1,0 +1,44 @@
+import unittest
+
+import pykokkos as pk
+
+from pykokkos.core.parsers import Parser
+from pykokkos.core.translators import PyKokkosMembers
+
+
+def implicit_leaf(i: int) -> int:
+    return i + 1
+
+
+def implicit_helper(i: int) -> int:
+    return implicit_leaf(i) * 2
+
+
+def unrelated_host_function() -> None:
+    raise RuntimeError("This function must not be translated")
+
+
+@pk.workunit
+def implicit_workunit(i: int, acc: pk.Acc[pk.int64]) -> None:
+    acc += implicit_helper(i)
+
+
+class TestImplicitFunctions(unittest.TestCase):
+    def test_discovers_only_reachable_functions(self):
+        parser = Parser(__file__)
+        entity = parser.get_entity("implicit_workunit")
+        members = PyKokkosMembers()
+
+        members.extract(entity, [])
+
+        names = {function.declname for function in members.pk_functions}
+        self.assertEqual({"implicit_helper", "implicit_leaf"}, names)
+
+    def test_executes_implicit_functions(self):
+        result = pk.parallel_reduce(10, implicit_workunit)
+
+        self.assertEqual(110, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_implicit_functions.py
+++ b/tests/test_implicit_functions.py
@@ -18,9 +18,18 @@ def unrelated_host_function() -> None:
     raise RuntimeError("This function must not be translated")
 
 
+def log(value):
+    raise RuntimeError("This host wrapper must not shadow the math intrinsic")
+
+
 @pk.workunit
 def implicit_workunit(i: int, acc: pk.Acc[pk.int64]) -> None:
     acc += implicit_helper(i)
+
+
+@pk.workunit
+def intrinsic_workunit(i: int, view: pk.View1D[pk.double]) -> None:
+    view[i] = log(view[i])
 
 
 class TestImplicitFunctions(unittest.TestCase):
@@ -33,6 +42,16 @@ class TestImplicitFunctions(unittest.TestCase):
 
         names = {function.declname for function in members.pk_functions}
         self.assertEqual({"implicit_helper", "implicit_leaf"}, names)
+
+    def test_math_intrinsic_takes_precedence_over_same_name_function(self):
+        parser = Parser(__file__)
+        entity = parser.get_entity("intrinsic_workunit")
+        members = PyKokkosMembers()
+
+        members.extract(entity, [])
+
+        names = {function.declname for function in members.pk_functions}
+        self.assertNotIn("log", names)
 
     def test_executes_implicit_functions(self):
         result = pk.parallel_reduce(10, implicit_workunit)


### PR DESCRIPTION
## Implicit helper functions

Standalone PyKokkos workunits can call compatible module-level Python functions without requiring the `@pk.function` decorator. PyKokkos discovers helper functions reachable from the workunit, recursively includes their same-module dependencies in translation, and excludes unrelated host-side functions.

```python
import pykokkos as pk


def my_printer(i: int) -> None:
    pk.printf("Index: %d\n", i)


@pk.workunit
def hello(i: int) -> None:
    my_printer(i)


pk.parallel_for("hello_loop", 10, hello)